### PR TITLE
Add creation of default Policies with a job to the helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Job to create default ingress and egress policies.
 - Add PSP for hubble-relay.
 
 ## [0.1.1] - 2022-04-07

--- a/helm/cilium/files/policies/egress.yaml
+++ b/helm/cilium/files/policies/egress.yaml
@@ -2,11 +2,6 @@ apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: allow-all-egress
-  ownerReferences:
-    - apiVersion: apps/v1
-      kind: DaemonSet
-      name: cilium
-      namespace: {{ .Release.Namespace }}
 spec:
   endpointSelector: {}
   egress:

--- a/helm/cilium/files/policies/egress.yaml
+++ b/helm/cilium/files/policies/egress.yaml
@@ -1,0 +1,9 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-all-egress
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+      - "all"

--- a/helm/cilium/files/policies/egress.yaml
+++ b/helm/cilium/files/policies/egress.yaml
@@ -2,6 +2,11 @@ apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: allow-all-egress
+  ownerReferences:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: cilium
+      namespace: {{ .Release.Namespace }}
 spec:
   endpointSelector: {}
   egress:

--- a/helm/cilium/files/policies/ingress.yaml
+++ b/helm/cilium/files/policies/ingress.yaml
@@ -1,0 +1,11 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-all-ingress-from-host
+  namespace: kube-system
+spec:
+  endpointSelector: {}
+  ingress:
+  - fromEntities:
+    - host
+    - remote-node

--- a/helm/cilium/files/policies/ingress.yaml
+++ b/helm/cilium/files/policies/ingress.yaml
@@ -2,7 +2,12 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: allow-all-ingress-from-host
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
+  ownerReferences:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: cilium
+      namespace: {{ .Release.Namespace }}
 spec:
   endpointSelector: {}
   ingress:

--- a/helm/cilium/files/policies/ingress.yaml
+++ b/helm/cilium/files/policies/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: allow-all-ingress-from-host
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 spec:
   endpointSelector: {}
   ingress:

--- a/helm/cilium/files/policies/ingress.yaml
+++ b/helm/cilium/files/policies/ingress.yaml
@@ -3,11 +3,6 @@ kind: CiliumNetworkPolicy
 metadata:
   name: allow-all-ingress-from-host
   namespace: {{ .Release.Namespace }}
-  ownerReferences:
-    - apiVersion: apps/v1
-      kind: DaemonSet
-      name: cilium
-      namespace: {{ .Release.Namespace }}
 spec:
   endpointSelector: {}
   ingress:

--- a/helm/cilium/templates/default-policies/configmap.yaml
+++ b/helm/cilium/templates/default-policies/configmap.yaml
@@ -15,8 +15,7 @@ data:
       endpointSelector: {}
       ingress:
       - fromEntities:
-        - host
-        - remote-node
+        - all
   egress.yaml: |-
     apiVersion: cilium.io/v2
     kind: CiliumClusterwideNetworkPolicy

--- a/helm/cilium/templates/default-policies/configmap.yaml
+++ b/helm/cilium/templates/default-policies/configmap.yaml
@@ -15,7 +15,8 @@ data:
       endpointSelector: {}
       ingress:
       - fromEntities:
-        - all
+        - host
+        - remote-node
   egress.yaml: |-
     apiVersion: cilium.io/v2
     kind: CiliumClusterwideNetworkPolicy

--- a/helm/cilium/templates/default-policies/configmap.yaml
+++ b/helm/cilium/templates/default-policies/configmap.yaml
@@ -6,25 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   ingress.yaml: |-
-    apiVersion: cilium.io/v2
-    kind: CiliumNetworkPolicy
-    metadata:
-      name: allow-all-ingress-from-host
-      namespace: kube-system
-    spec:
-      endpointSelector: {}
-      ingress:
-      - fromEntities:
-        - host
-        - remote-node
+    {{- .Files.Get "files/policies/ingress.yaml" | nindent 4 }}
   egress.yaml: |-
-    apiVersion: cilium.io/v2
-    kind: CiliumClusterwideNetworkPolicy
-    metadata:
-      name: allow-all-egress
-    spec:
-      endpointSelector: {}
-      egress:
-        - toEntities:
-          - "all"
+    {{- .Files.Get "files/policies/egress.yaml" | nindent 4 }}
 {{- end }}

--- a/helm/cilium/templates/default-policies/configmap.yaml
+++ b/helm/cilium/templates/default-policies/configmap.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.defaultPolicies.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-default-policies
+  namespace: {{ .Release.Namespace }}
+data:
+  ingress.yaml: |-
+    apiVersion: cilium.io/v2
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: allow-all-ingress-from-host
+      namespace: kube-system
+    spec:
+      endpointSelector: {}
+      ingress:
+      - fromEntities:
+        - host
+        - remote-node
+  egress.yaml: |-
+    apiVersion: cilium.io/v2
+    kind: CiliumClusterwideNetworkPolicy
+    metadata:
+      name: allow-all-egress
+    spec:
+      endpointSelector: {}
+      egress:
+        - toEntities:
+          - "all"
+{{- end }}

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
       {{- with .Values.defaultPolicies.tolerations }}
       tolerations:
-        {{- toYaml . | indent 8 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
       - name: policies

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: cilium-create-default-policies
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 50
   template:

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -31,10 +31,5 @@ spec:
         - name: policies
           mountPath: /policies
         args:
-        - sh
-        - -c
-        - |
-          set -o errexit ; set -o xtrace ; set -o nounset
-
-          kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /policies/ 2>&1
+        - apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /policies/ 2>&1
 {{- end -}}

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.defaultPolicies.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cilium-create-default-policies
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: cilium-create-default-policies
+spec:
+  backoffLimit: 50
+  template:
+    metadata:
+      labels:
+        app: cilium-create-default-policies
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
+      {{- with .Values.defaultPolicies.tolerations }}
+      tolerations:
+        {{- toYaml . | indent 8 }}
+      {{- end }}
+      volumes:
+      - name: policies
+        configMap:
+          name: cilium-default-policies
+      containers:
+      - name: cilium-create-default-policies
+        image: "quay.io/giantswarm/docker-kubectl:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: policies
+          mountPath: /policies
+        args:
+        - sh
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+
+          kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /policies/ 2>&1
+{{- end -}}

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
+      priorityClassName: system-cluster-critical
       {{- with .Values.defaultPolicies.tolerations }}
       tolerations:
         {{- toYaml . | nindent 6 }}

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -30,6 +30,12 @@ spec:
         volumeMounts:
         - name: policies
           mountPath: /policies
+        command:
+        - sh
         args:
-        - apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /policies/ 2>&1
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+
+          kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /policies/ 2>&1
 {{- end -}}

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "1"
-    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 50
   template:

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "1"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   backoffLimit: 50
   template:

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -24,6 +24,23 @@ spec:
       - name: policies
         configMap:
           name: cilium-default-policies
+      initContainers:
+      - name: wait-crds
+        image: "quay.io/giantswarm/docker-kubectl:latest"
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          for crd in ciliumnetworkpolicies.cilium.io ciliumclusterwidenetworkpolicies.cilium.io
+          do
+            while ! kubectl get crd $crd
+            do
+              echo "Waiting for CRD $crd to exist"
+              sleep 5
+            done
+          done
       containers:
       - name: cilium-create-default-policies
         image: "quay.io/giantswarm/docker-kubectl:latest"

--- a/helm/cilium/templates/default-policies/rbac.yaml
+++ b/helm/cilium/templates/default-policies/rbac.yaml
@@ -12,6 +12,15 @@ rules:
   verbs:
   - patch
   - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  resourceNames:
+  - ciliumnetworkpolicies.cilium.io
+  - ciliumclusterwidenetworkpolicies.cilium.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/cilium/templates/default-policies/rbac.yaml
+++ b/helm/cilium/templates/default-policies/rbac.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.defaultPolicies.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
+rules:
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumclusterwidenetworkpolicies
+  - ciliumnetworkpolicies
+  verbs:
+  - patch
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/cilium/templates/default-policies/serviceaccount.yaml
+++ b/helm/cilium/templates/default-policies/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.defaultPolicies.enabled .Values.serviceAccounts.defaultPolicies.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccounts.defaultPolicies.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccounts.defaultPolicies.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -69,6 +69,10 @@ serviceAccounts:
     create: true
     name: hubble-generate-certs
     annotations: {}
+  defaultPolicies:
+    create: true
+    name: cilium-default-policies
+    annotations: {}
 
 # -- Install the cilium agent resources.
 agent: true
@@ -1795,3 +1799,10 @@ cgroup:
 # -- Configure whether to enable auto detect of terminating state for endpoints
 # in order to support graceful termination.
 enableK8sTerminatingEndpoint: true
+
+defaultPolicies:
+  enabled: false
+  # -- Node tolerations for default-policies job scheduling to nodes with taints
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  tolerations:
+  - operator: Exists


### PR DESCRIPTION
We currently rely on `cluster-resources-app` to create `Cilium` network policies.
I believe it is cleaner and easier to use if we bundle the creation of such policies in the cilium app itself.

With this PR I added a new job, similar to the one we have for cert-manager for a similar use case, that creates the policies after cilium CRDs are created.

The feature is disabled by default to be backward compatible.

