### PR TITLE
Add NetworkPolicy to allow ingress traffic towards hubble proxy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add NetworkPolicy to allow ingress traffic towards hubble proxy.
+
 ## [0.2.0] - 2022-05-02
 
 ### Added

--- a/helm/cilium/templates/hubble-relay/networkpolicy.yaml
+++ b/helm/cilium/templates/hubble-relay/networkpolicy.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.hubble.enabled .Values.hubble.relay.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-relay
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: hubble-relay
+spec:
+  ingress:
+    - ports:
+        - port: {{ .Values.hubble.relay.listenPort }}
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  policyTypes:
+    - Ingress
+{{- end }}


### PR DESCRIPTION
hubble-proxy needs to accept traffic to its port in order for hubble UI to display data.