### PR TITLE
Added missing volume type to hubble psp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added missing PSP property for hubble
+
 ## [0.2.1] - 2022-06-06
 
 ### Added

--- a/helm/cilium/templates/hubble-relay/podsecuritypolicy.yaml
+++ b/helm/cilium/templates/hubble-relay/podsecuritypolicy.yaml
@@ -10,6 +10,7 @@ spec:
     - 'configMap'
     - 'projected'
     - 'hostPath'
+    - 'secrets'
   hostNetwork: false
   hostIPC: false
   hostPID: false


### PR DESCRIPTION
This PR:

- updates the PSP for hubble to allow it to mount secrets as a volume
