### PR TITLE
Run default-policies job also post-upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the `cilium-create-default-policies` Job as a post-upgrade hook
+
 ## [0.2.3] - 2022-06-21
 
 ### Fixed

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: cilium-create-default-policies
   annotations:
-    helm.sh/hook: post-install
+    helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "1"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:
Adds the create-default-policies Job as a post-upgrade hook.

The hook doesn't seem to work in the first place, I suspect because the app-operator is doing an upgrade.
In any case it seems like this is a good idea as it will update the default policies if they change.

<!--
### Testing

Description on how cilium can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cilium installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly
-->
<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid. 
**(haven't changed)**
