### PR TITLE
Default policies improve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use retagged images instead of upstream ones.
+- Run the default policies creation job in hostNetwork.
 
 ## [0.2.4] - 2022-06-29
 

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: cilium-create-default-policies
     spec:
+      hostNetwork: true
       restartPolicy: OnFailure
       serviceAccountName: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
       priorityClassName: system-cluster-critical

--- a/helm/cilium/templates/default-policies/podsecuritypolicy.yaml
+++ b/helm/cilium/templates/default-policies/podsecuritypolicy.yaml
@@ -10,6 +10,7 @@ spec:
     - ALL
   volumes:
     - 'configMap'
+    - 'projected'
   hostNetwork: true
   hostIPC: false
   hostPID: false

--- a/helm/cilium/templates/default-policies/podsecuritypolicy.yaml
+++ b/helm/cilium/templates/default-policies/podsecuritypolicy.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.defaultPolicies.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cilium-default-policies-psp
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-default-policies-psp
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - cilium-default-policies-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-default-policies-psp
+roleRef:
+  kind: ClusterRole
+  name: cilium-default-policies-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccounts.defaultPolicies.name | quote }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
Based on kube-scheduler timing,  it might be that the job that creates default policies runs too late, when cilium network policies are already in place.
This means that the job's calls to the api-server are blocked because there are no policies to allow them.

This PR runs the job in hostNetwork to avoid this chicken-egg problem.

### Testing

Description on how cilium can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cilium installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
