### PR TITLE
Restrict default egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Instead of allowing egress towards all endpoints, by default only allow access to the api server for all pods.
+
 ## [0.2.5] - 2022-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Instead of allowing egress towards all endpoints, by default only allow access to the api server for all pods.
+- Instead of allowing egress towards all endpoints, by default only allow access to the api server for all pods in `kube-system` and `giantswarm` namespaces.
 
 ## [0.2.5] - 2022-07-25
 

--- a/helm/cilium/files/policies/egress.yaml
+++ b/helm/cilium/files/policies/egress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   endpointSelector: {}
   egress:
-    toEntities:
+  - toEntities:
     - kube-apiserver
 ---
 apiVersion: cilium.io/v2
@@ -17,5 +17,5 @@ metadata:
 spec:
   endpointSelector: {}
   egress:
-    toEntities:
+  - toEntities:
     - kube-apiserver

--- a/helm/cilium/files/policies/egress.yaml
+++ b/helm/cilium/files/policies/egress.yaml
@@ -1,21 +1,23 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: allow-apiserver-access
+  name: allow-cluster-access
   namespace: kube-system
 spec:
   endpointSelector: {}
   egress:
   - toEntities:
     - kube-apiserver
+    - cluster
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: allow-apiserver-access
+  name: allow-cluster-access
   namespace: giantswarm
 spec:
   endpointSelector: {}
   egress:
   - toEntities:
     - kube-apiserver
+    - cluster

--- a/helm/cilium/files/policies/egress.yaml
+++ b/helm/cilium/files/policies/egress.yaml
@@ -1,9 +1,9 @@
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
-  name: allow-all-egress
+  name: allow-apiserver-access
 spec:
   endpointSelector: {}
   egress:
-    - toEntities:
-      - "all"
+    toEntities:
+    - kube-apiserver

--- a/helm/cilium/files/policies/egress.yaml
+++ b/helm/cilium/files/policies/egress.yaml
@@ -1,7 +1,19 @@
 apiVersion: cilium.io/v2
-kind: CiliumClusterwideNetworkPolicy
+kind: CiliumNetworkPolicy
 metadata:
   name: allow-apiserver-access
+  namespace: kube-system
+spec:
+  endpointSelector: {}
+  egress:
+    toEntities:
+    - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-apiserver-access
+  namespace: giantswarm
 spec:
   endpointSelector: {}
   egress:


### PR DESCRIPTION
In legacy WCs, we used to have a restrict-all default network policy for pods in `giantswarm` and `kube-system` namespaces: https://github.com/giantswarm/k8scloudconfig/blob/master/files/k8s-resource/network_policies.yaml

# Problem 1:
Currently, we ship an "allow all egress" policy as part of cilium installation that breaks behavior compatibility in legacy cluster.
This PR deletes such policy as it's wrong.

# Problem 2:
This meant that all apps needed to ship their own NetworkPolicy in order to access in-cluster resources such as the api-server.
We used to create such policies using an ipBlock selector like here for example: https://github.com/giantswarm/cert-manager-app/blob/master/helm/cert-manager-app/templates/cainjector-np.yaml#L24

Unfortunately, the ipBlock selector does not work on cilium for in-cluster CIDRs: https://github.com/cilium/cilium/issues/19601
It's a design choice and it'll never work.

Now, the right solution would be to have all the apps that need to access the API server ship their own `CiliumNetworkPolicy`, but I reckon that is overkill and also breaks the apps for usage without cilium.

This PR creates 2 default ciliumnetworkpolicies to automatically allow all pods in `kube-system` and `giantswarm` to connect to the API server and to all host-level services (such as `hostNetwork: true` pods).



WDYT?

### Testing

Description on how cilium can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cilium installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
