### PR TITLE
Cleanup iptables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add init container that cleans up iptables rules before starting cilium agent.
+
 ## [0.2.6] - 2022-07-26
 
 ### Changed

--- a/helm/cilium/templates/cilium-agent/daemonset.yaml
+++ b/helm/cilium/templates/cilium-agent/daemonset.yaml
@@ -438,6 +438,13 @@ spec:
         resources:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
+      {{ if and (.Values.cleanupKubeProxy (not (eq .Values.kubeProxyReplacement "disabled"))) }}
+      - name: cleanup-kube-proxy-iptables
+        image: {{ include "cilium.image" .Values.image | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - iptables-save | grep -v KUBE | iptables-restore
+      {{ end }}
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}

--- a/helm/cilium/templates/cilium-agent/daemonset.yaml
+++ b/helm/cilium/templates/cilium-agent/daemonset.yaml
@@ -443,7 +443,10 @@ spec:
         image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-        - iptables-save | grep -v KUBE | iptables-restore
+        - sh
+        - -c
+        - |
+          iptables-save | grep -v KUBE | iptables-restore
       {{ end }}
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}

--- a/helm/cilium/templates/cilium-agent/daemonset.yaml
+++ b/helm/cilium/templates/cilium-agent/daemonset.yaml
@@ -438,7 +438,7 @@ spec:
         resources:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
-      {{ if and (.Values.cleanupKubeProxy (not (eq .Values.kubeProxyReplacement "disabled"))) }}
+      {{ if and (.Values.cleanupKubeProxy) (not (eq .Values.kubeProxyReplacement "disabled")) }}
       - name: cleanup-kube-proxy-iptables
         image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -1807,4 +1807,6 @@ defaultPolicies:
   tolerations:
   - operator: Exists
 
+# If true, it adds an initContainer to cilium-agent pods that cleans up any legacy kube-proxy iptables rules from the node before running cilium.
+# Only makes sense when `kubeProxyReplacement` is enabled (i.e. not set to 'disabled').
 cleanupKubeProxy: false

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -1806,3 +1806,5 @@ defaultPolicies:
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
   - operator: Exists
+
+cleanupKubeProxy: false


### PR DESCRIPTION
When switching from aws-cni/kube-proxy to cilium in kube-proxy mode, we need to cleanup iptables rules before running cilium, otherwise services end up being broken (see https://docs.cilium.io/en/v1.12/gettingstarted/kubeproxy-free/#quick-start )



This PR:

- adds a new initContainer, disabled by default and added through an helm variable, that cleans up iptables rules before starting cilium agent.

### Testing

Description on how cilium can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cilium installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
