### PR TITLE
Fix kube-proxy cleanup init container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Run `cleanup-kube-proxy-iptables` container in cilium agent in privileged mode.
+- Use iptables-nft binaries for `cleanup-kube-proxy-iptables` container.
+
 ## [0.3.0] - 2022-10-06
 
 ### Added

--- a/helm/cilium/templates/cilium-agent/daemonset.yaml
+++ b/helm/cilium/templates/cilium-agent/daemonset.yaml
@@ -442,11 +442,13 @@ spec:
       - name: cleanup-kube-proxy-iptables
         image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          privileged: true
         command:
         - sh
         - -c
         - |
-          iptables-save | grep -v KUBE | iptables-restore
+          /usr/sbin/iptables-nft-save | grep -v KUBE | grep -v cali | /usr/sbin/iptables-nft-restore
       {{ end }}
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}


### PR DESCRIPTION
- Run `cleanup-kube-proxy-iptables` container in cilium agent in privileved mode
- Use iptables-nft binaries for `cleanup-kube-proxy-iptables` container.

