### PR TITLE
Bumped cilium to v1.11.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped default version to v1.11.9
+
 ## [0.4.0] - 2022-10-13
 
 ### Changed

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -86,7 +86,7 @@ rollOutCiliumPods: false
 # -- Agent container image.
 image:
   repository: quay.io/giantswarm/cilium
-  tag: v1.11.2
+  tag: v1.11.9
   pullPolicy: IfNotPresent
   # cilium-digest
   digest: ""
@@ -651,7 +651,7 @@ hubble:
       # Defaults to midnight of the first day of every fourth month. For syntax, see
       # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
       schedule: "0 0 1 */4 *"
-      
+
       # [Example]
       # certManagerIssuerRef:
       #   group: cert-manager.io
@@ -686,7 +686,7 @@ hubble:
     # -- Hubble-relay container image.
     image:
       repository: quay.io/giantswarm/hubble-relay
-      tag: v1.11.2
+      tag: v1.11.9
        # hubble-relay-digest
       digest: ""
       useDigest: false
@@ -1317,7 +1317,7 @@ operator:
   # -- cilium-operator image.
   image:
     repository: quay.io/giantswarm/cilium-operator
-    tag: v1.11.2
+    tag: v1.11.9
     # operator-generic-digest
     genericDigest: ""
     # operator-azure-digest
@@ -1535,7 +1535,7 @@ preflight:
   # -- Cilium pre-flight image.
   image:
     repository: quay.io/giantswarm/cilium
-    tag: v1.11.2
+    tag: v1.11.9
     # cilium-digest
     digest: ""
     useDigest: false
@@ -1642,7 +1642,7 @@ clustermesh:
     # -- Clustermesh API server image.
     image:
       repository: quay.io/giantswarm/cilium-clustermesh-apiserver
-      tag: v1.11.2
+      tag: v1.11.9
       # clustermesh-apiserver-digest
       digest: ""
       useDigest: false
@@ -1736,7 +1736,7 @@ clustermesh:
         # fourth month. For syntax, see
         # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
         # schedule: "0 0 1 */4 *"
-        
+
         # [Example]
         # certManagerIssuerRef:
         #   group: cert-manager.io


### PR DESCRIPTION
This PR:

- bumped default version to latest v1.11 patch (v1.11.9)  

This is required for compatibility with Ubuntu 22.04 (see https://github.com/kubernetes-sigs/kubespray/issues/9039#issuecomment-1199904978 for details)

### Testing

Description on how cilium can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cilium installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
