### PR TITLE
Cilium operator service account is missing node read permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.1] - 2022-10-25
 - cilium-operator service account also needs read access to the `nodes` api end point at the cluster scope  
 otherwise it raises the error:  
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2022-10-25
+- cilium-operator service account also needs read access to the `nodes` api end point at the cluster scope  
+otherwise it raises the error:  
+```
+failed to list *v1.Node: nodes is forbidden: User "system:serviceaccount:kube-system:cilium-operator" cannot list resource "nodes" in API group "" at the cluster scope"
+```
+
 ## [0.5.0] - 2022-10-18
 
 ### Changed

--- a/helm/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/helm/cilium/templates/cilium-operator/clusterrole.yaml
@@ -76,6 +76,8 @@ rules:
   - endpoints
   # to check apiserver connectivity
   - namespaces
+  # cilium operator also requires access to the nodes
+  - nodes
   verbs:
   - get
   - list


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- allows the `cilium-operator` service account to read the  `nodes` resource from the k8s api.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
