### PR TITLE
Enable Monitoring and Hubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump all manifests to upstream version 1.13.
+- Enable Hubble
+- Enable Monitoring for Agent, Operator and Hubble
 
 ## [0.7.0] - 2023-02-10
 

--- a/helm/cilium/templates/cilium-agent/service.yaml
+++ b/helm/cilium/templates/cilium-agent/service.yaml
@@ -42,6 +42,10 @@ spec:
   selector:
     k8s-app: cilium
   ports:
+  - name: metrics
+    port: {{ .Values.prometheus.port }}
+    protocol: TCP
+    targetPort: prometheus
   - name: envoy-metrics
     port: {{ .Values.proxy.prometheus.port }}
     protocol: TCP

--- a/helm/cilium/templates/cilium-operator/service.yaml
+++ b/helm/cilium/templates/cilium-operator/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.operator.enabled .Values.operator.prometheus.enabled .Values.operator.prometheus.serviceMonitor.enabled }}
+{{- if and .Values.operator.enabled .Values.operator.prometheus.enabled }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/helm/cilium/templates/hubble-relay/networkpolicy.yaml
+++ b/helm/cilium/templates/hubble-relay/networkpolicy.yaml
@@ -11,6 +11,7 @@ spec:
   ingress:
     - ports:
         - port: {{ .Values.hubble.relay.listenPort }}
+        - port: {{ .Values.hubble.relay.prometheus.port }}
   podSelector:
     matchLabels:
       k8s-app: hubble-relay

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -966,7 +966,7 @@ hubble:
 
   relay:
     # -- Enable Hubble Relay (requires hubble.enabled=true)
-    enabled: false
+    enabled: true
 
     # -- Roll out Hubble Relay pods automatically when configmap is updated.
     rollOutPods: false
@@ -1104,7 +1104,7 @@ hubble:
     # -- Enable prometheus metrics for hubble-relay on the configured port at
     # /metrics
     prometheus:
-      enabled: false
+      enabled: true
       port: 9966
       serviceMonitor:
         # -- Enable service monitors.
@@ -1134,7 +1134,7 @@ hubble:
 
   ui:
     # -- Whether to enable the Hubble UI.
-    enabled: false
+    enabled: true
 
     standalone:
       # -- When true, it will allow installing the Hubble UI only, without checking dependencies.


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Enables hubble
- Enables operator monitoring

Prometheus scraping is not directly enabled in this application as it would make it depend on ServiceMonitor CRD being installed before the CNI.

https://github.com/giantswarm/cilium-servicemonitors-app was created to provide the ServiceMonitors to be scraped by the Observability Bundle's Prometheus agent.

### Testing

Description on how cilium can be tested.

- [ ] fresh install works
  - [x] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [x] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cilium installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
