### PR TITLE
Use `image.registry` value as image registry for all containers in the chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `image.registry` value as image registry for all containers in the chart.
+
 ## [0.8.0] - 2023-03-08
 
 ### Changed

--- a/helm/cilium/templates/cilium-agent/daemonset.yaml
+++ b/helm/cilium/templates/cilium-agent/daemonset.yaml
@@ -79,7 +79,7 @@ spec:
       {{- end }}
       containers:
       - name: cilium-agent
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.sleepAfterInit }}
         command:
@@ -372,7 +372,7 @@ spec:
         {{- end }}
       {{- if .Values.monitor.enabled }}
       - name: cilium-monitor
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /bin/bash
@@ -401,7 +401,7 @@ spec:
       {{- end }}
       initContainers:
       - name: config
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - cilium
@@ -442,7 +442,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: CGROUP_ROOT
@@ -488,7 +488,7 @@ spec:
               - ALL
           {{- end}}
       - name: apply-sysctl-overwrites
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: BIN_PATH
@@ -533,7 +533,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -554,7 +554,7 @@ spec:
       {{- end }}
       {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
       - name: wait-for-node-init
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - sh
@@ -570,7 +570,7 @@ spec:
           mountPath: "/tmp/cilium-bootstrap.d"
       {{- end }}
       - name: clean-cilium-state
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /init-container.sh
@@ -633,7 +633,7 @@ spec:
         {{- end }}
       {{- if and .Values.waitForKubeProxy (ne $kubeProxyReplacement "strict") }}
       - name: wait-for-kube-proxy
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true
@@ -666,7 +666,7 @@ spec:
       {{- end }} # wait-for-kube-proxy
       {{ if and (.Values.cleanupKubeProxy) (not (eq .Values.kubeProxyReplacement "disabled")) }}
       - name: cleanup-kube-proxy-iptables
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true

--- a/helm/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/helm/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
       containers:
         - name: node-init
-          image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
+          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.nodeinit.image }}"
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           lifecycle:
             {{- if .Values.eni.enabled }}

--- a/helm/cilium/templates/cilium-operator/_helpers.tpl
+++ b/helm/cilium/templates/cilium-operator/_helpers.tpl
@@ -31,6 +31,6 @@ Return cilium operator image
 {{- else -}}
 {{- $cloud := include "cilium.operator.cloud" . }}
 {{- $imageDigest := include "cilium.operator.imageDigestName" . }}
-{{- printf "%s-%s%s:%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $imageDigest -}}
+{{- printf "%s/%s-%s%s:%s%s" .Values.image.registry .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $imageDigest -}}
 {{- end -}}
 {{- end -}}

--- a/helm/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/helm/cilium/templates/cilium-preflight/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       initContainers:
         - name: clean-cilium-state
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.preflight.image }}"
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/echo"]
           args:
@@ -38,7 +38,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
       containers:
         - name: cilium-pre-flight-check
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.preflight.image }}"
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:
@@ -86,7 +86,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
         {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.preflight.image }}"
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           name: cilium-pre-flight-fqdn-precache
           command: ["/bin/sh"]

--- a/helm/cilium/templates/cilium-preflight/deployment.yaml
+++ b/helm/cilium/templates/cilium-preflight/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: cnp-validator
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.preflight.image }}"
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:

--- a/helm/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/helm/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       initContainers:
       - name: etcd-init
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image }}"
         imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
@@ -78,7 +78,7 @@ spec:
         {{- end }}
       containers:
       - name: etcd
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image }}"
         imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
         command:
         - /usr/local/bin/etcd
@@ -114,7 +114,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       - name: apiserver
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.clustermesh.apiserver.image }}"
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
         - /usr/bin/clustermesh-apiserver

--- a/helm/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/helm/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: certgen
-          image: {{ include "cilium.image" .Values.certgen.image | quote }}
+          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.certgen.image }}"
           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
           command:
             - "/usr/bin/cilium-certgen"

--- a/helm/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/helm/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -86,7 +86,7 @@ spec:
           value: "revision"
         - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
           value: "25000"
-        image: {{ include "cilium.image" .Values.etcd.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.etcd.image }}"
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
         terminationMessagePolicy: FallbackToLogsOnError

--- a/helm/cilium/templates/hubble-relay/deployment.yaml
+++ b/helm/cilium/templates/hubble-relay/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
         - name: hubble-relay
-          image: {{ include "cilium.image" .Values.hubble.relay.image | quote }}
+          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.hubble.relay.image }}"
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
           command:
             - hubble-relay

--- a/helm/cilium/templates/hubble-ui/deployment.yaml
+++ b/helm/cilium/templates/hubble-ui/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
       - name: frontend
-        image: {{ include "cilium.image" .Values.hubble.ui.frontend.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.hubble.ui.frontend.image }}"
         imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
         ports:
         - name: http
@@ -67,7 +67,7 @@ spec:
             mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
       - name: backend
-        image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
+        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.hubble.ui.backend.image }}"
         imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
         env:
         - name: EVENTS_SERVER_PORT

--- a/helm/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
+++ b/helm/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: certgen
-          image: {{ include "cilium.image" .Values.certgen.image | quote }}
+          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.certgen.image }}"
           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
           command:
             - "/usr/bin/cilium-certgen"

--- a/helm/cilium/values.schema.json
+++ b/helm/cilium/values.schema.json
@@ -1,0 +1,2948 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "MTU": {
+            "type": "integer"
+        },
+        "affinity": {
+            "type": "object",
+            "properties": {
+                "podAntiAffinity": {
+                    "type": "object",
+                    "properties": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "labelSelector": {
+                                        "type": "object",
+                                        "properties": {
+                                            "matchLabels": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "k8s-app": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "topologyKey": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "agent": {
+            "type": "boolean"
+        },
+        "agentNotReadyTaintKey": {
+            "type": "string"
+        },
+        "aksbyocni": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "alibabacloud": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "annotateK8sNode": {
+            "type": "boolean"
+        },
+        "autoDirectNodeRoutes": {
+            "type": "boolean"
+        },
+        "azure": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "bandwidthManager": {
+            "type": "object",
+            "properties": {
+                "bbr": {
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "bgp": {
+            "type": "object",
+            "properties": {
+                "announce": {
+                    "type": "object",
+                    "properties": {
+                        "loadbalancerIP": {
+                            "type": "boolean"
+                        },
+                        "podCIDR": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "bgpControlPlane": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "bpf": {
+            "type": "object",
+            "properties": {
+                "clockProbe": {
+                    "type": "boolean"
+                },
+                "ctAnyMax": {
+                    "type": "null"
+                },
+                "ctTcpMax": {
+                    "type": "null"
+                },
+                "hostLegacyRouting": {
+                    "type": "null"
+                },
+                "lbExternalClusterIP": {
+                    "type": "boolean"
+                },
+                "lbMapMax": {
+                    "type": "integer"
+                },
+                "mapDynamicSizeRatio": {
+                    "type": "null"
+                },
+                "masquerade": {
+                    "type": "null"
+                },
+                "monitorAggregation": {
+                    "type": "string"
+                },
+                "monitorFlags": {
+                    "type": "string"
+                },
+                "monitorInterval": {
+                    "type": "string"
+                },
+                "natMax": {
+                    "type": "null"
+                },
+                "neighMax": {
+                    "type": "null"
+                },
+                "policyMapMax": {
+                    "type": "integer"
+                },
+                "preallocateMaps": {
+                    "type": "boolean"
+                },
+                "root": {
+                    "type": "string"
+                },
+                "tproxy": {
+                    "type": "null"
+                },
+                "vlanBypass": {
+                    "type": "null"
+                }
+            }
+        },
+        "certgen": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "override": {
+                            "type": "null"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "ttlSecondsAfterFinished": {
+                    "type": "integer"
+                }
+            }
+        },
+        "cgroup": {
+            "type": "object",
+            "properties": {
+                "autoMount": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "resources": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "hostRoot": {
+                    "type": "string"
+                }
+            }
+        },
+        "cleanBpfState": {
+            "type": "boolean"
+        },
+        "cleanState": {
+            "type": "boolean"
+        },
+        "cleanupKubeProxy": {
+            "type": "boolean"
+        },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "clustermesh": {
+            "type": "object",
+            "properties": {
+                "apiserver": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "type": "object",
+                            "properties": {
+                                "podAntiAffinity": {
+                                    "type": "object",
+                                    "properties": {
+                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "matchLabels": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "k8s-app": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "topologyKey": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "etcd": {
+                            "type": "object",
+                            "properties": {
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "override": {
+                                            "type": "null"
+                                        },
+                                        "pullPolicy": {
+                                            "type": "string"
+                                        },
+                                        "repository": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "init": {
+                                    "type": "object",
+                                    "properties": {
+                                        "resources": {
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "resources": {
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "extraEnv": {
+                            "type": "array"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "override": {
+                                    "type": "null"
+                                },
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                },
+                                "useDigest": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "nodeSelector": {
+                            "type": "object",
+                            "properties": {
+                                "kubernetes.io/os": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "podAnnotations": {
+                            "type": "object"
+                        },
+                        "podDisruptionBudget": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "maxUnavailable": {
+                                    "type": "integer"
+                                },
+                                "minAvailable": {
+                                    "type": "null"
+                                }
+                            }
+                        },
+                        "podLabels": {
+                            "type": "object"
+                        },
+                        "priorityClassName": {
+                            "type": "string"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "nodePort": {
+                                    "type": "integer"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "admin": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cert": {
+                                            "type": "string"
+                                        },
+                                        "key": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "auto": {
+                                    "type": "object",
+                                    "properties": {
+                                        "certManagerIssuerRef": {
+                                            "type": "object"
+                                        },
+                                        "certValidityDuration": {
+                                            "type": "integer"
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "method": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "ca": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cert": {
+                                            "type": "string"
+                                        },
+                                        "key": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "client": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cert": {
+                                            "type": "string"
+                                        },
+                                        "key": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "remote": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cert": {
+                                            "type": "string"
+                                        },
+                                        "key": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "server": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cert": {
+                                            "type": "string"
+                                        },
+                                        "extraDnsNames": {
+                                            "type": "array"
+                                        },
+                                        "extraIpAddresses": {
+                                            "type": "array"
+                                        },
+                                        "key": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                            "type": "array"
+                        },
+                        "updateStrategy": {
+                            "type": "object",
+                            "properties": {
+                                "rollingUpdate": {
+                                    "type": "object",
+                                    "properties": {
+                                        "maxUnavailable": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "clusters": {
+                            "type": "array"
+                        },
+                        "domain": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "useAPIServer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "cni": {
+            "type": "object",
+            "properties": {
+                "binPath": {
+                    "type": "string"
+                },
+                "chainingMode": {
+                    "type": "string"
+                },
+                "confFileMountPath": {
+                    "type": "string"
+                },
+                "confPath": {
+                    "type": "string"
+                },
+                "configMapKey": {
+                    "type": "string"
+                },
+                "customConf": {
+                    "type": "boolean"
+                },
+                "exclusive": {
+                    "type": "boolean"
+                },
+                "hostConfDirMountPath": {
+                    "type": "string"
+                },
+                "install": {
+                    "type": "boolean"
+                },
+                "logFile": {
+                    "type": "string"
+                }
+            }
+        },
+        "conntrackGCInterval": {
+            "type": "string"
+        },
+        "containerRuntime": {
+            "type": "object",
+            "properties": {
+                "integration": {
+                    "type": "string"
+                }
+            }
+        },
+        "crdWaitTimeout": {
+            "type": "string"
+        },
+        "customCalls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "daemon": {
+            "type": "object",
+            "properties": {
+                "allowedConfigOverrides": {
+                    "type": "null"
+                },
+                "blockedConfigOverrides": {
+                    "type": "null"
+                },
+                "configSources": {
+                    "type": "null"
+                },
+                "runPath": {
+                    "type": "string"
+                }
+            }
+        },
+        "debug": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "verbose": {
+                    "type": "null"
+                }
+            }
+        },
+        "defaultPolicies": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "operator": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "disableEndpointCRD": {
+            "type": "string"
+        },
+        "dnsPolicy": {
+            "type": "string"
+        },
+        "dnsProxy": {
+            "type": "object",
+            "properties": {
+                "dnsRejectResponseCode": {
+                    "type": "string"
+                },
+                "enableDnsCompression": {
+                    "type": "boolean"
+                },
+                "endpointMaxIpPerHostname": {
+                    "type": "integer"
+                },
+                "idleConnectionGracePeriod": {
+                    "type": "string"
+                },
+                "maxDeferredConnectionDeletes": {
+                    "type": "integer"
+                },
+                "minTtl": {
+                    "type": "integer"
+                },
+                "preCache": {
+                    "type": "string"
+                },
+                "proxyPort": {
+                    "type": "integer"
+                },
+                "proxyResponseMaxDelay": {
+                    "type": "string"
+                }
+            }
+        },
+        "egressGateway": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "installRoutes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "enableCiliumEndpointSlice": {
+            "type": "boolean"
+        },
+        "enableCnpStatusUpdates": {
+            "type": "boolean"
+        },
+        "enableCriticalPriorityClass": {
+            "type": "boolean"
+        },
+        "enableIPv4Masquerade": {
+            "type": "boolean"
+        },
+        "enableIPv6BIGTCP": {
+            "type": "boolean"
+        },
+        "enableIPv6Masquerade": {
+            "type": "boolean"
+        },
+        "enableK8sEventHandover": {
+            "type": "boolean"
+        },
+        "enableK8sTerminatingEndpoint": {
+            "type": "boolean"
+        },
+        "enableRuntimeDeviceDetection": {
+            "type": "boolean"
+        },
+        "enableXTSocketFallback": {
+            "type": "boolean"
+        },
+        "encryption": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "interface": {
+                    "type": "string"
+                },
+                "ipsec": {
+                    "type": "object",
+                    "properties": {
+                        "interface": {
+                            "type": "string"
+                        },
+                        "keyFile": {
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "secretName": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "keyFile": {
+                    "type": "string"
+                },
+                "mountPath": {
+                    "type": "string"
+                },
+                "nodeEncryption": {
+                    "type": "boolean"
+                },
+                "secretName": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "wireguard": {
+                    "type": "object",
+                    "properties": {
+                        "userspaceFallback": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "endpointHealthChecking": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpointRoutes": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpointStatus": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "eni": {
+            "type": "object",
+            "properties": {
+                "awsEnablePrefixDelegation": {
+                    "type": "boolean"
+                },
+                "awsReleaseExcessIPs": {
+                    "type": "boolean"
+                },
+                "ec2APIEndpoint": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "eniTags": {
+                    "type": "object"
+                },
+                "gcInterval": {
+                    "type": "string"
+                },
+                "gcTags": {
+                    "type": "object"
+                },
+                "iamRole": {
+                    "type": "string"
+                },
+                "instanceTagsFilter": {
+                    "type": "array"
+                },
+                "subnetIDsFilter": {
+                    "type": "array"
+                },
+                "subnetTagsFilter": {
+                    "type": "array"
+                },
+                "updateEC2AdapterLimitViaAPI": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "etcd": {
+            "type": "object",
+            "properties": {
+                "clusterDomain": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "endpoints": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "extraArgs": {
+                    "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "override": {
+                            "type": "null"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "k8sService": {
+                    "type": "boolean"
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "properties": {
+                        "kubernetes.io/os": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podDisruptionBudget": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxUnavailable": {
+                            "type": "integer"
+                        },
+                        "minAvailable": {
+                            "type": "null"
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "ssl": {
+                    "type": "boolean"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "operator": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "topologySpreadConstraints": {
+                    "type": "array"
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "maxSurge": {
+                                    "type": "integer"
+                                },
+                                "maxUnavailable": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "externalIPs": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "externalWorkloads": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "extraArgs": {
+            "type": "array"
+        },
+        "extraConfig": {
+            "type": "object"
+        },
+        "extraContainers": {
+            "type": "array"
+        },
+        "extraEnv": {
+            "type": "array"
+        },
+        "extraHostPathMounts": {
+            "type": "array"
+        },
+        "extraVolumeMounts": {
+            "type": "array"
+        },
+        "extraVolumes": {
+            "type": "array"
+        },
+        "gatewayAPI": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "secretsNamespace": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "sync": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "gke": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "healthChecking": {
+            "type": "boolean"
+        },
+        "healthPort": {
+            "type": "integer"
+        },
+        "hostFirewall": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "hostPort": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "hubble": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "listenAddress": {
+                    "type": "string"
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "dashboards": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "label": {
+                                    "type": "string"
+                                },
+                                "labelValue": {
+                                    "type": "string"
+                                },
+                                "namespace": {
+                                    "type": "null"
+                                }
+                            }
+                        },
+                        "enableOpenMetrics": {
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "type": "null"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "serviceAnnotations": {
+                            "type": "object"
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "interval": {
+                                    "type": "string"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                },
+                                "metricRelabelings": {
+                                    "type": "null"
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "replacement": {
+                                                "type": "string"
+                                            },
+                                            "sourceLabels": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "targetLabel": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "peerService": {
+                    "type": "object",
+                    "properties": {
+                        "clusterDomain": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "preferIpv6": {
+                    "type": "boolean"
+                },
+                "relay": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "type": "object",
+                            "properties": {
+                                "podAffinity": {
+                                    "type": "object",
+                                    "properties": {
+                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "matchLabels": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "k8s-app": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "topologyKey": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "dialTimeout": {
+                            "type": "null"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraEnv": {
+                            "type": "array"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "override": {
+                                    "type": "null"
+                                },
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                },
+                                "useDigest": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "listenHost": {
+                            "type": "string"
+                        },
+                        "listenPort": {
+                            "type": "string"
+                        },
+                        "nodeSelector": {
+                            "type": "object",
+                            "properties": {
+                                "kubernetes.io/os": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "podAnnotations": {
+                            "type": "object"
+                        },
+                        "podDisruptionBudget": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "maxUnavailable": {
+                                    "type": "integer"
+                                },
+                                "minAvailable": {
+                                    "type": "null"
+                                }
+                            }
+                        },
+                        "podLabels": {
+                            "type": "object"
+                        },
+                        "pprof": {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "priorityClassName": {
+                            "type": "string"
+                        },
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "serviceMonitor": {
+                                    "type": "object",
+                                    "properties": {
+                                        "annotations": {
+                                            "type": "object"
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "interval": {
+                                            "type": "string"
+                                        },
+                                        "labels": {
+                                            "type": "object"
+                                        },
+                                        "metricRelabelings": {
+                                            "type": "null"
+                                        },
+                                        "relabelings": {
+                                            "type": "null"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "retryTimeout": {
+                            "type": "null"
+                        },
+                        "rollOutPods": {
+                            "type": "boolean"
+                        },
+                        "securityContext": {
+                            "type": "object"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "nodePort": {
+                                    "type": "integer"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "sortBufferDrainTimeout": {
+                            "type": "null"
+                        },
+                        "sortBufferLenMax": {
+                            "type": "null"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                        },
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "client": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cert": {
+                                            "type": "string"
+                                        },
+                                        "key": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "server": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cert": {
+                                            "type": "string"
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "extraDnsNames": {
+                                            "type": "array"
+                                        },
+                                        "extraIpAddresses": {
+                                            "type": "array"
+                                        },
+                                        "key": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                            "type": "array"
+                        },
+                        "updateStrategy": {
+                            "type": "object",
+                            "properties": {
+                                "rollingUpdate": {
+                                    "type": "object",
+                                    "properties": {
+                                        "maxUnavailable": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "skipUnknownCGroupIDs": {
+                    "type": "null"
+                },
+                "socketPath": {
+                    "type": "string"
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "auto": {
+                            "type": "object",
+                            "properties": {
+                                "certManagerIssuerRef": {
+                                    "type": "object"
+                                },
+                                "certValidityDuration": {
+                                    "type": "integer"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "method": {
+                                    "type": "string"
+                                },
+                                "schedule": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "ca": {
+                            "type": "object",
+                            "properties": {
+                                "cert": {
+                                    "type": "string"
+                                },
+                                "key": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "server": {
+                            "type": "object",
+                            "properties": {
+                                "cert": {
+                                    "type": "string"
+                                },
+                                "extraDnsNames": {
+                                    "type": "array"
+                                },
+                                "extraIpAddresses": {
+                                    "type": "array"
+                                },
+                                "key": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "ui": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "type": "object"
+                        },
+                        "backend": {
+                            "type": "object",
+                            "properties": {
+                                "extraEnv": {
+                                    "type": "array"
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "override": {
+                                            "type": "null"
+                                        },
+                                        "pullPolicy": {
+                                            "type": "string"
+                                        },
+                                        "repository": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "resources": {
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "frontend": {
+                            "type": "object",
+                            "properties": {
+                                "extraEnv": {
+                                    "type": "array"
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "override": {
+                                            "type": "null"
+                                        },
+                                        "pullPolicy": {
+                                            "type": "string"
+                                        },
+                                        "repository": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "resources": {
+                                    "type": "object"
+                                },
+                                "server": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ipv6": {
+                                            "type": "object",
+                                            "properties": {
+                                                "enabled": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "ingress": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "className": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "hosts": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "tls": {
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "nodeSelector": {
+                            "type": "object",
+                            "properties": {
+                                "kubernetes.io/os": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "podAnnotations": {
+                            "type": "object"
+                        },
+                        "podDisruptionBudget": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "maxUnavailable": {
+                                    "type": "integer"
+                                },
+                                "minAvailable": {
+                                    "type": "null"
+                                }
+                            }
+                        },
+                        "podLabels": {
+                            "type": "object"
+                        },
+                        "priorityClassName": {
+                            "type": "string"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "rollOutPods": {
+                            "type": "boolean"
+                        },
+                        "securityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "fsGroup": {
+                                    "type": "integer"
+                                },
+                                "runAsGroup": {
+                                    "type": "integer"
+                                },
+                                "runAsUser": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "nodePort": {
+                                    "type": "integer"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "standalone": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "certsVolume": {
+                                            "type": "object"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "client": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cert": {
+                                            "type": "string"
+                                        },
+                                        "key": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                            "type": "array"
+                        },
+                        "updateStrategy": {
+                            "type": "object",
+                            "properties": {
+                                "rollingUpdate": {
+                                    "type": "object",
+                                    "properties": {
+                                        "maxUnavailable": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "identityAllocationMode": {
+            "type": "string"
+        },
+        "identityChangeGracePeriod": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "digest": {
+                    "type": "string"
+                },
+                "override": {
+                    "type": "null"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "useDigest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "null"
+        },
+        "ingressController": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "enforceHttps": {
+                    "type": "boolean"
+                },
+                "ingressLBAnnotationPrefixes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "loadbalancerMode": {
+                    "type": "string"
+                },
+                "secretsNamespace": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "sync": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "insecureNodePort": {
+                            "type": "null"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "secureNodePort": {
+                            "type": "null"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "installIptablesRules": {
+            "type": "boolean"
+        },
+        "installNoConntrackIptablesRules": {
+            "type": "boolean"
+        },
+        "ipMasqAgent": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "ipam": {
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": "string"
+                },
+                "operator": {
+                    "type": "object",
+                    "properties": {
+                        "clusterPoolIPv4MaskSize": {
+                            "type": "integer"
+                        },
+                        "clusterPoolIPv4PodCIDR": {
+                            "type": "string"
+                        },
+                        "clusterPoolIPv4PodCIDRList": {
+                            "type": "array"
+                        },
+                        "clusterPoolIPv6MaskSize": {
+                            "type": "integer"
+                        },
+                        "clusterPoolIPv6PodCIDR": {
+                            "type": "string"
+                        },
+                        "clusterPoolIPv6PodCIDRList": {
+                            "type": "array"
+                        },
+                        "externalAPILimitBurstSize": {
+                            "type": "null"
+                        },
+                        "externalAPILimitQPS": {
+                            "type": "null"
+                        }
+                    }
+                }
+            }
+        },
+        "ipv4": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "ipv4NativeRoutingCIDR": {
+            "type": "string"
+        },
+        "ipv6": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "ipv6NativeRoutingCIDR": {
+            "type": "string"
+        },
+        "k8s": {
+            "type": "object"
+        },
+        "k8sServiceHost": {
+            "type": "string"
+        },
+        "k8sServicePort": {
+            "type": "string"
+        },
+        "keepDeprecatedLabels": {
+            "type": "boolean"
+        },
+        "keepDeprecatedProbes": {
+            "type": "boolean"
+        },
+        "kubeConfigPath": {
+            "type": "string"
+        },
+        "kubeProxyReplacementHealthzBindAddr": {
+            "type": "string"
+        },
+        "l2NeighDiscovery": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "refreshPeriod": {
+                    "type": "string"
+                }
+            }
+        },
+        "l7Proxy": {
+            "type": "boolean"
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "loadBalancer": {
+            "type": "object",
+            "properties": {
+                "l7": {
+                    "type": "object",
+                    "properties": {
+                        "algorithm": {
+                            "type": "string"
+                        },
+                        "backend": {
+                            "type": "string"
+                        },
+                        "ports": {
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "localRedirectPolicy": {
+            "type": "boolean"
+        },
+        "logSystemLoad": {
+            "type": "boolean"
+        },
+        "maglev": {
+            "type": "object"
+        },
+        "monitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "nat46x64Gateway": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "nodePort": {
+            "type": "object",
+            "properties": {
+                "autoProtectPortRange": {
+                    "type": "boolean"
+                },
+                "bindProtection": {
+                    "type": "boolean"
+                },
+                "enableHealthCheck": {
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "nodeSelector": {
+            "type": "object",
+            "properties": {
+                "kubernetes.io/os": {
+                    "type": "string"
+                }
+            }
+        },
+        "nodeinit": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "bootstrapFile": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "extraEnv": {
+                    "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "override": {
+                            "type": "null"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "properties": {
+                        "kubernetes.io/os": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "add": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "privileged": {
+                            "type": "boolean"
+                        },
+                        "seLinuxOptions": {
+                            "type": "object",
+                            "properties": {
+                                "level": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "operator": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "operator": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object",
+                    "properties": {
+                        "podAntiAffinity": {
+                            "type": "object",
+                            "properties": {
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "matchLabels": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "io.cilium/app": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "topologyKey": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "dnsPolicy": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "endpointGCInterval": {
+                    "type": "string"
+                },
+                "extraArgs": {
+                    "type": "array"
+                },
+                "extraEnv": {
+                    "type": "array"
+                },
+                "extraHostPathMounts": {
+                    "type": "array"
+                },
+                "extraVolumeMounts": {
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "type": "array"
+                },
+                "identityGCInterval": {
+                    "type": "string"
+                },
+                "identityHeartbeatTimeout": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "alibabacloudDigest": {
+                            "type": "string"
+                        },
+                        "awsDigest": {
+                            "type": "string"
+                        },
+                        "azureDigest": {
+                            "type": "string"
+                        },
+                        "genericDigest": {
+                            "type": "string"
+                        },
+                        "override": {
+                            "type": "null"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "suffix": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "useDigest": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "nodeGCInterval": {
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "properties": {
+                        "kubernetes.io/os": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podDisruptionBudget": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxUnavailable": {
+                            "type": "integer"
+                        },
+                        "minAvailable": {
+                            "type": "null"
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "pprof": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "prometheus": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "interval": {
+                                    "type": "string"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                },
+                                "metricRelabelings": {
+                                    "type": "null"
+                                },
+                                "relabelings": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                },
+                "removeNodeTaints": {
+                    "type": "boolean"
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "rollOutPods": {
+                    "type": "boolean"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "setNodeNetworkStatus": {
+                    "type": "boolean"
+                },
+                "skipCNPStatusStartupClean": {
+                    "type": "boolean"
+                },
+                "skipCRDCreation": {
+                    "type": "boolean"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "operator": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "topologySpreadConstraints": {
+                    "type": "array"
+                },
+                "unmanagedPodWatcher": {
+                    "type": "object",
+                    "properties": {
+                        "intervalSeconds": {
+                            "type": "integer"
+                        },
+                        "restart": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "maxSurge": {
+                                    "type": "integer"
+                                },
+                                "maxUnavailable": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "pmtuDiscovery": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podLabels": {
+            "type": "object"
+        },
+        "policyEnforcementMode": {
+            "type": "string"
+        },
+        "pprof": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "preflight": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object",
+                    "properties": {
+                        "podAffinity": {
+                            "type": "object",
+                            "properties": {
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "matchLabels": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "k8s-app": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "topologyKey": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "extraEnv": {
+                    "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "digest": {
+                            "type": "string"
+                        },
+                        "override": {
+                            "type": "null"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "useDigest": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "properties": {
+                        "kubernetes.io/os": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podDisruptionBudget": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxUnavailable": {
+                            "type": "integer"
+                        },
+                        "minAvailable": {
+                            "type": "null"
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "integer"
+                },
+                "tofqdnsPreCache": {
+                    "type": "string"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "effect": {
+                                "type": "string"
+                            },
+                            "key": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "validateCNPs": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string"
+        },
+        "prometheus": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "metrics": {
+                    "type": "null"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "metricRelabelings": {
+                            "type": "null"
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "replacement": {
+                                        "type": "string"
+                                    },
+                                    "sourceLabels": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "targetLabel": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "proxy": {
+            "type": "object",
+            "properties": {
+                "prometheus": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "sidecarImageRegex": {
+                    "type": "string"
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "remoteNodeIdentity": {
+            "type": "boolean"
+        },
+        "resourceQuotas": {
+            "type": "object",
+            "properties": {
+                "cilium": {
+                    "type": "object",
+                    "properties": {
+                        "hard": {
+                            "type": "object",
+                            "properties": {
+                                "pods": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "operator": {
+                    "type": "object",
+                    "properties": {
+                        "hard": {
+                            "type": "object",
+                            "properties": {
+                                "pods": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "resources": {
+            "type": "object"
+        },
+        "rollOutCiliumPods": {
+            "type": "boolean"
+        },
+        "sctp": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "applySysctlOverwrites": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "ciliumAgent": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cleanCiliumState": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "mountCgroup": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "privileged": {
+                    "type": "boolean"
+                },
+                "seLinuxOptions": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccounts": {
+            "type": "object",
+            "properties": {
+                "cilium": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "clustermeshApiserver": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "clustermeshcertgen": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "defaultPolicies": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "etcd": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "hubblecertgen": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "operator": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "preflight": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "relay": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "ui": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "sleepAfterInit": {
+            "type": "boolean"
+        },
+        "socketLB": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "sockops": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "svcSourceRangeCheck": {
+            "type": "boolean"
+        },
+        "synchronizeK8sNodes": {
+            "type": "boolean"
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "integer"
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "ca": {
+                    "type": "object",
+                    "properties": {
+                        "cert": {
+                            "type": "string"
+                        },
+                        "certValidityDuration": {
+                            "type": "integer"
+                        },
+                        "key": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "secretsBackend": {
+                    "type": "string"
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "operator": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "tunnel": {
+            "type": "string"
+        },
+        "tunnelPort": {
+            "type": "integer"
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxUnavailable": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "vtep": {
+            "type": "object",
+            "properties": {
+                "cidr": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "endpoint": {
+                    "type": "string"
+                },
+                "mac": {
+                    "type": "string"
+                },
+                "mask": {
+                    "type": "string"
+                }
+            }
+        },
+        "waitForKubeProxy": {
+            "type": "boolean"
+        },
+        "wellKnownIdentities": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -104,8 +104,9 @@ rollOutCiliumPods: false
 
 # -- Agent container image.
 image:
+  registry: docker.io
   override: ~
-  repository: "quay.io/giantswarm/cilium"
+  repository: "giantswarm/cilium"
   tag: "v1.13.0"
   pullPolicy: "IfNotPresent"
   # cilium-digest
@@ -798,7 +799,7 @@ socketLB:
 certgen:
   image:
     override: ~
-    repository: "quay.io/giantswarm/cilium-certgen"
+    repository: "giantswarm/cilium-certgen"
     tag: "v0.1.8"
     pullPolicy: "IfNotPresent"
   # -- Seconds after which the completed job pod will be deleted
@@ -974,7 +975,7 @@ hubble:
     # -- Hubble-relay container image.
     image:
       override: ~
-      repository: "quay.io/giantswarm/hubble-relay"
+      repository: "giantswarm/hubble-relay"
       tag: "v1.13.0"
        # hubble-relay-digest
       digest: ""
@@ -1176,7 +1177,7 @@ hubble:
       # -- Hubble-ui backend image.
       image:
         override: ~
-        repository: "quay.io/giantswarm/hubble-ui-backend"
+        repository: "giantswarm/hubble-ui-backend"
         tag: "v0.10.0"
         pullPolicy: "IfNotPresent"
 
@@ -1196,7 +1197,7 @@ hubble:
       # -- Hubble-ui frontend image.
       image:
         override: ~
-        repository: "quay.io/giantswarm/hubble-ui"
+        repository: "giantswarm/hubble-ui"
         tag: "v0.10.0"
         pullPolicy: "IfNotPresent"
 
@@ -1704,7 +1705,7 @@ etcd:
   # -- cilium-etcd-operator image.
   image:
     override: ~
-    repository: "quay.io/giantswarm/cilium-etcd-operator"
+    repository: "giantswarm/cilium-etcd-operator"
     tag: "v2.0.7"
     pullPolicy: "IfNotPresent"
 
@@ -1798,7 +1799,7 @@ operator:
   # -- cilium-operator image.
   image:
     override: ~
-    repository: "quay.io/giantswarm/cilium-operator"
+    repository: "giantswarm/cilium-operator"
     tag: "v1.13.0"
     # operator-generic-digest
     genericDigest: ""
@@ -1979,7 +1980,7 @@ nodeinit:
   # -- node-init image.
   image:
     override: ~
-    repository: "quay.io/giantswarm/cilium-startup-script"
+    repository: "giantswarm/cilium-startup-script"
     tag: "d69851597ea019af980891a4628fb36b7880ec26"
     pullPolicy: "IfNotPresent"
 
@@ -2054,7 +2055,7 @@ preflight:
   # -- Cilium pre-flight image.
   image:
     override: ~
-    repository: "quay.io/giantswarm/cilium"
+    repository: "giantswarm/cilium"
     tag: "v1.13.0"
     # cilium-digest
     digest: ""
@@ -2193,7 +2194,7 @@ clustermesh:
     # -- Clustermesh API server image.
     image:
       override: ~
-      repository: "quay.io/giantswarm/cilium-clustermesh-apiserver"
+      repository: "giantswarm/cilium-clustermesh-apiserver"
       tag: "v1.13.0"
       # clustermesh-apiserver-digest
       digest: ""
@@ -2204,7 +2205,7 @@ clustermesh:
       # -- Clustermesh API server etcd image.
       image:
         override: ~
-        repository: "quay.io/giantswarm/etcd"
+        repository: "giantswarm/etcd"
         tag: "v3.5.4"
         pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26243

This PR:

- Use `image.registry` value as image registry for all containers in the chart

### Testing

Description on how cilium can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cilium installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
