### PR TITLE
Add network policy to allow exposing hubble UI through ingress.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add network policy to allow exposing hubble UI through ingress.
+
 ## [0.9.0] - 2023-03-20
 
 ### Changed

--- a/helm/cilium/templates/hubble-ui/networkpolicy.yaml
+++ b/helm/cilium/templates/hubble-ui/networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.hubble.ui.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    k8s-app: hubble-ui
+    app.kubernetes.io/name: hubble-ui
+    app.kubernetes.io/part-of: cilium
+  name: hubble-ui
+  namespace: {{ .Release.Namespace }}
+spec:
+  ingress:
+    - ports:
+        - port: 8081
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+      app.kubernetes.io/name: hubble-ui
+      app.kubernetes.io/part-of: cilium
+      {{- with .Values.hubble.ui.podLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  policyTypes:
+    - Ingress
+{{- end }}


### PR DESCRIPTION
When exposing hubble ui through ingress (disabled by default) other pods (ingress controller in this case) need to be able to connect to the hubble UI pod.
Since cilium is installed in kube-system, by default all ingress traffic towards pods is blocked, hence we need a networkpolicy to enable traffic.

This PR:

- does what I wrote above

### Testing

Description on how cilium can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cilium installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
