### PR TITLE
Add missing capabilities check for PSP on default-policies installer job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add missing conditional for PSP rendering of default-policies installer job
+
 ## [0.10.0] - 2023-05-16
 
 ### Changed

--- a/helm/cilium/templates/default-policies/podsecuritypolicy.yaml
+++ b/helm/cilium/templates/default-policies/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.defaultPolicies.enabled -}}
+{{- if and .Values.defaultPolicies.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2533

This PR:

- adds the `capabilities check` for rendering psp to the `default-policies job`

### Testing

Description on how cilium can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cilium installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
