### PR TITLE
Support creating `CiliumNetworkPolicy` manifests that allow egress requests to DNS and proxy hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support creating `CiliumNetworkPolicy` manifests that allow egress requests to DNS and proxy hosts
+
 ## [0.11.0] - 2023-07-10
 
 ### Changed
@@ -60,14 +64,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Enable LocalRedirectPolicy for node-local-cache and kiam. 
+- Enable LocalRedirectPolicy for node-local-cache and kiam.
 
 
 ## [0.6.1] - 2022-11-22
 
 ### Changed
 
-- Align Helm chart ownership and CODEOWNERS file. 
+- Align Helm chart ownership and CODEOWNERS file.
 
 ## [0.6.0] - 2022-11-07
 

--- a/helm/cilium/templates/extra-policies/configmap.yaml
+++ b/helm/cilium/templates/extra-policies/configmap.yaml
@@ -1,0 +1,73 @@
+{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-extra-policies
+  namespace: {{ .Release.Namespace }}
+data:
+  policies.yaml: |-
+    {{- if $.Values.extraPolicies.allowEgressToCoreDNS.enabled }}
+    {{- range $_, $ns := (required "extraPolicies.allowEgressToCoreDNS.namespaces must be filled for extraPolicies.allowEgressToCoreDNS.enabled=true" $.Values.extraPolicies.allowEgressToCoreDNS.namespaces) }}
+    ---
+    apiVersion: cilium.io/v2
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: cilium-extra-policies-dns
+      namespace: {{ $ns | quote }}
+    spec:
+      endpointSelector: {} # any
+
+      egress:
+        - toServices:
+            - k8sServiceSelector:
+                namespace: kube-system
+                selector:
+                  matchLabels:
+                    k8s-app: coredns
+
+          toPorts:
+            - ports:
+                - port: "1053" # must be the target port, not service port
+                  protocol: ANY
+    {{- if $.Values.extraPolicies.allowEgressToProxy.enabled }}
+
+              # Required so Cilium registers DNS responses in the FQDN cache
+              # as needed for the proxy access rule below which uses `toFQDNs`
+              # (https://docs.cilium.io/en/stable/security/policy/language/#example)
+              rules:
+                dns:
+                  - matchPattern: "*"
+    {{ end -}}
+    {{ end -}}
+    {{ end -}}
+
+    {{- if $.Values.extraPolicies.allowEgressToProxy.enabled }}
+    {{- range $_, $ns := (required "extraPolicies.allowEgressToProxy.namespaces must be filled for extraPolicies.allowEgressToProxy.enabled=true" $.Values.extraPolicies.allowEgressToProxy.namespaces) }}
+    ---
+    apiVersion: cilium.io/v2
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: cilium-extra-policies-proxy
+      namespace: {{ $ns | quote }}
+    spec:
+      endpointSelector: {} # any
+
+      egress:
+        {{ if not $.Values.extraPolicies.allowEgressToCoreDNS.enabled }}
+          {{ fail "extraPolicies.allowEgressToCoreDNS.enabled=true is required for extraPolicies.allowEgressToProxy.enabled since DNS requests are captured by Cilium for the L7 toFQDNs feature. Make sure the same namespaces are allowed for DNS egress." }}
+        {{ end -}}
+        - toFQDNs:
+            # The whole cluster should be allowed to reach the proxy. This currently does not limit the port range.
+            {{/* Extract hostname without the port */}}
+            {{- range $_, $proxyUrl := ((list
+                  (regexReplaceAll ":[0-9]+.*" $.Values.extraPolicies.allowEgressToProxy.httpProxy "")
+                  (regexReplaceAll ":[0-9]+.*" $.Values.extraPolicies.allowEgressToProxy.httpsProxy "")
+                ) | uniq) }}
+            {{- if $proxyUrl }}
+            - matchName: {{ index (urlParse $proxyUrl) "host" | required "Failed to parse hostname in extraPolicies.allowEgressToProxy.httpProxy or extraPolicies.allowEgressToProxy.httpsProxy" | quote }}
+            {{- end }}
+            {{- end }}
+    {{ end -}}
+    {{ end -}}
+
+{{- end }}

--- a/helm/cilium/templates/extra-policies/job.yaml
+++ b/helm/cilium/templates/extra-policies/job.yaml
@@ -1,0 +1,64 @@
+{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cilium-create-extra-policies
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: cilium-create-extra-policies
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 50
+  template:
+    metadata:
+      labels:
+        app: cilium-create-extra-policies
+    spec:
+      hostNetwork: true
+      restartPolicy: OnFailure
+      serviceAccountName: {{ .Values.serviceAccounts.extraPolicies.name | quote }}
+      priorityClassName: system-cluster-critical
+      {{- with .Values.extraPolicies.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      volumes:
+      - name: policies
+        configMap:
+          name: cilium-extra-policies
+      initContainers:
+      - name: wait-crds
+        image: "quay.io/giantswarm/docker-kubectl:latest"
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          for crd in ciliumnetworkpolicies.cilium.io ciliumclusterwidenetworkpolicies.cilium.io
+          do
+            while ! kubectl get crd $crd
+            do
+              echo "Waiting for CRD $crd to exist"
+              sleep 5
+            done
+          done
+      containers:
+      - name: cilium-create-extra-policies
+        image: "quay.io/giantswarm/docker-kubectl:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: policies
+          mountPath: /policies
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+
+          kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /policies/ 2>&1
+{{- end -}}

--- a/helm/cilium/templates/extra-policies/podsecuritypolicy.yaml
+++ b/helm/cilium/templates/extra-policies/podsecuritypolicy.yaml
@@ -1,0 +1,56 @@
+{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cilium-extra-policies-psp
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'projected'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-extra-policies-psp
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - cilium-extra-policies-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-extra-policies-psp
+roleRef:
+  kind: ClusterRole
+  name: cilium-extra-policies-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccounts.extraPolicies.name | quote }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/cilium/templates/extra-policies/rbac.yaml
+++ b/helm/cilium/templates/extra-policies/rbac.yaml
@@ -1,0 +1,37 @@
+{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.serviceAccounts.extraPolicies.name | quote }}
+rules:
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumclusterwidenetworkpolicies
+  - ciliumnetworkpolicies
+  verbs:
+  - patch
+  - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  resourceNames:
+  - ciliumnetworkpolicies.cilium.io
+  - ciliumclusterwidenetworkpolicies.cilium.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.serviceAccounts.extraPolicies.name | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.serviceAccounts.extraPolicies.name | quote }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccounts.extraPolicies.name | quote }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/cilium/templates/extra-policies/serviceaccount.yaml
+++ b/helm/cilium/templates/extra-policies/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and (or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled) .Values.serviceAccounts.extraPolicies.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccounts.extraPolicies.name | quote }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccounts.extraPolicies.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccounts.extraPolicies.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/cilium/values.schema.json
+++ b/helm/cilium/values.schema.json
@@ -964,6 +964,65 @@
         "extraHostPathMounts": {
             "type": "array"
         },
+        "extraPolicies": {
+            "type": "object",
+            "description": "Which extra network policies to install alongside Cilium.",
+            "properties": {
+                "allowEgressToCoreDNS": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Allow all DNS egress to CoreDNS."
+                        },
+                        "namespaces": {
+                            "type": "array",
+                            "default": ["giantswarm", "kube-system"],
+                            "description": "For which namespaces to install this policy.",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "allowEgressToProxy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Allow all egress to the HTTP/HTTPS proxy via L7 CiliumNetworkPolicy rule. For now this only supports an FQDN, not an IP address, inside the `httpProxy`/`httpsProxy` URLs."
+                        },
+                        "httpProxy": {
+                            "type": "string",
+                            "title": "HTTP proxy"
+                        },
+                        "httpsProxy": {
+                            "type": "string",
+                            "title": "HTTPS proxy"
+                        },
+                        "namespaces": {
+                            "type": "array",
+                            "default": ["giantswarm", "kube-system"],
+                            "description": "For which namespaces to install this policy.",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "operator": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "extraVolumeMounts": {
             "type": "array"
         },
@@ -2740,6 +2799,20 @@
                     }
                 },
                 "etcd": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "extraPolicies": {
                     "type": "object",
                     "properties": {
                         "annotations": {

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -89,6 +89,10 @@ serviceAccounts:
     create: true
     name: cilium-default-policies
     annotations: {}
+  extraPolicies:
+    create: true
+    name: cilium-extra-policies
+    annotations: {}
 
 # -- Configure termination grace period for cilium-agent DaemonSet.
 terminationGracePeriodSeconds: 1
@@ -1607,7 +1611,7 @@ prometheus:
   # list. (+metric_foo to enable metric_foo , -metric_bar to disable
   # metric_bar).
   # ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics
-  metrics: 
+  metrics:
    - +cilium_bpf_map_pressure
 
 # -- Configure Istio proxy options.
@@ -2455,6 +2459,24 @@ defaultPolicies:
   enabled: false
   # -- Node tolerations for default-policies job scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  tolerations:
+  - operator: Exists
+
+extraPolicies:
+  allowEgressToCoreDNS:
+    enabled: false
+    namespaces:
+      - giantswarm
+      - kube-system
+
+  allowEgressToProxy:
+    enabled: false
+    httpProxy: ""
+    httpsProxy: ""
+    namespaces:
+      - giantswarm
+      - kube-system
+
   tolerations:
   - operator: Exists
 


### PR DESCRIPTION
Supersedes https://github.com/giantswarm/cluster-aws/pull/341 – it didn't fit in `cluster-aws` since we need to want to be able to install the policies in MCs and WCs that have a proxy.

This PR adds a way to allow traffic to DNS and, in case of proxy-private clusters, to the proxy host via L7 network policies.

The `Job` and related resources were copied from the `default-policies` solution and not added on top since the "default" aren't very configurable and I didn't want to mess with those. They are also not well-commented and therefore a candidate for removal or changes.

### Testing

Tested like this:

- [x] fresh install works
  - [x] AWS
  - [ ] Azure
  - [ ] KVM
- [n/a] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.