### PR TITLE
Support removal of previously-deployed default policies by setting `defaultPolicies.enabled=false` and `defaultPolicies.remove=false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support removal of previously-deployed default policies by setting `defaultPolicies.enabled=false` and `defaultPolicies.remove=false`
+
 ## [0.12.0] - 2023-09-05
 
 ### Added

--- a/helm/cilium/templates/default-policies/configmap.yaml
+++ b/helm/cilium/templates/default-policies/configmap.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.defaultPolicies.enabled -}}
+{{- if and .Values.defaultPolicies.enabled .Values.defaultPolicies.remove -}}
+{{- fail "defaultPolicies.enabled and defaultPolicies.remove cannot both be true" -}}
+{{- end -}}
+{{- if or .Values.defaultPolicies.enabled .Values.defaultPolicies.remove -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/cilium/templates/default-policies/job.yaml
+++ b/helm/cilium/templates/default-policies/job.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.defaultPolicies.enabled -}}
+{{- if or .Values.defaultPolicies.enabled .Values.defaultPolicies.remove -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cilium-create-default-policies
+  name: cilium-{{ ternary "remove" "create" .Values.defaultPolicies.remove }}-default-policies
   namespace: {{ .Release.Namespace }}
   labels:
-    app: cilium-create-default-policies
+    app: cilium-{{ ternary "remove" "create" .Values.defaultPolicies.remove }}-default-policies
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "1"
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: cilium-create-default-policies
+        app: cilium-{{ ternary "remove" "create" .Values.defaultPolicies.remove }}-default-policies
     spec:
       hostNetwork: true
       restartPolicy: OnFailure
@@ -47,7 +47,7 @@ spec:
             done
           done
       containers:
-      - name: cilium-create-default-policies
+      - name: cilium-{{ ternary "remove" "create" .Values.defaultPolicies.remove }}-default-policies
         image: "quay.io/giantswarm/docker-kubectl:latest"
         imagePullPolicy: IfNotPresent
         volumeMounts:
@@ -60,5 +60,13 @@ spec:
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
 
-          kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /policies/ 2>&1
+          kubectl \
+{{- if .Values.defaultPolicies.remove }}
+            delete \
+            --ignore-not-found \
+{{- else }}
+            apply \
+            --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts \
+{{- end }}
+            -f /policies/ 2>&1
 {{- end -}}

--- a/helm/cilium/templates/default-policies/podsecuritypolicy.yaml
+++ b/helm/cilium/templates/default-policies/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.defaultPolicies.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") -}}
+{{- if and (or .Values.defaultPolicies.enabled .Values.defaultPolicies.remove) (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/cilium/templates/default-policies/rbac.yaml
+++ b/helm/cilium/templates/default-policies/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.defaultPolicies.enabled -}}
+{{- if or .Values.defaultPolicies.enabled .Values.defaultPolicies.remove -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -12,6 +12,7 @@ rules:
   verbs:
   - patch
   - create
+  - delete
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/helm/cilium/templates/default-policies/serviceaccount.yaml
+++ b/helm/cilium/templates/default-policies/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.defaultPolicies.enabled .Values.serviceAccounts.defaultPolicies.create -}}
+{{- if and (or .Values.defaultPolicies.enabled .Values.defaultPolicies.remove) .Values.serviceAccounts.defaultPolicies.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/cilium/values.schema.json
+++ b/helm/cilium/values.schema.json
@@ -633,6 +633,10 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "remove": {
+                    "type": "boolean",
+                    "description": "Only usable together with `defaultPolicies.enabled=false`. This removes any existing policies if they were installed previously via `defaultPolicies.enabled=true`."
+                },
                 "tolerations": {
                     "type": "array",
                     "items": {

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -2565,6 +2565,7 @@ sctp:
 
 defaultPolicies:
   enabled: false
+  remove: false
   # -- Node tolerations for default-policies job scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27266

As discussed in the issue, we don't need the so-called default-policies' allow rules anymore, given how all operators were instrumented with their own, minimal network policies (`giantswarm` + `kube-system` namespaces).

Tested by upgrading on a fresh CAPA MC. The policies are gone and operator logs still show no problems.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
