### PR TITLE
Replace `ToServices`/`ToPorts` combination in CiliumNetworkPolicy because of breakage in Cilium v1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Replace `ToServices`/`ToPorts` combination in CiliumNetworkPolicy because of breakage in Cilium v1.14
+
 ## [0.19.1] - 2024-01-18
 
 ### Changed

--- a/helm/cilium/templates/extra-policies/configmap.yaml
+++ b/helm/cilium/templates/extra-policies/configmap.yaml
@@ -18,12 +18,10 @@ data:
       endpointSelector: {} # any
 
       egress:
-        - toServices:
-            - k8sServiceSelector:
-                namespace: kube-system
-                selector:
-                  matchLabels:
-                    k8s-app: coredns
+        - toEndpoints:
+            - matchLabels:
+                k8s-app: coredns
+                k8s:io.kubernetes.pod.namespace: kube-system
 
           toPorts:
             - ports:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3155