### PR TITLE
Support CAPA clusters for ENI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support CAPA clusters for ENI mode
+
 ## [0.20.1] - 2024-02-27
 
 ### Changed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,0 +1,7 @@
+.PHONY: ensure-schema-gen
+ensure-schema-gen:
+	@helm schema-gen --help &>/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git
+
+.PHONY: schema-gen
+schema-gen: ensure-schema-gen ## Generates the values schema file
+	@cd helm/cilium && helm schema-gen values.yaml > values.schema.json

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ git cherry-pick a4b22dee87ba3663f967f6dd6d8e666c849c742d^..25c449534cc325a5798fc
 It's probable that conflicts will happen, so we need to fix those when applying the commits.
 One last thing we need to do in our fork is to update the `values.schema.json` file, because upstream does not provide one. You can do it with
 ```
-helm schema-gen install/kubernetes/cilium/values.yaml > install/kubernetes/cilium/values.schema.json
+make schema-gen
 ```
 
 Don't forget to commit the changes, if any.

--- a/helm/cilium/templates/cilium-cni-configmap.yaml
+++ b/helm/cilium/templates/cilium-cni-configmap.yaml
@@ -28,7 +28,11 @@ data:
                 "giantswarm.io/subnet-type": "aws-cni"
               }
               {{- end}}
-              {{- if .Values.eksMode }}
+
+              {{- if .Values.eksMode -}}
+              {{/*
+                  For CAPA EKS clusters (https://github.com/giantswarm/cluster-eks)
+              */}}
               "first-interface-index": 1,
               "security-group-tags": {
                 "kubernetes.io/cluster/{{ .Values.cluster.name }}": "owned",
@@ -37,6 +41,22 @@ data:
               "subnet-tags": {
                 "sigs.k8s.io/cluster-api-provider-aws/cluster/{{ .Values.cluster.name }}": "owned",
                 "sigs.k8s.io/cluster-api-provider-aws/association": "secondary",
+                "sigs.k8s.io/cluster-api-provider-aws/role": "private"
+              }
+              {{- end }}
+
+              {{- if and (not .Values.eksMode) (eq .Values.provider "capa") -}}
+              {{/*
+                  For CAPA EC2-based clusters (https://github.com/giantswarm/cluster-aws)
+
+                  The full ENI mode feature is in development (https://github.com/giantswarm/roadmap/issues/2563). Open TODOs:
+
+                  - Once a secondary VPC CIDR is added, this must be set as well for the below subnet tags selector: `"sigs.k8s.io/cluster-api-provider-aws/association": "secondary",`
+                  - And `"security-group-tags": [...]` should be added once there's a specific pod security group.
+              */}}
+              "first-interface-index": 1,
+              "subnet-tags": {
+                "sigs.k8s.io/cluster-api-provider-aws/cluster/{{ .Values.cluster.name }}": "owned",
                 "sigs.k8s.io/cluster-api-provider-aws/role": "private"
               }
               {{- end }}


### PR DESCRIPTION
Introduce `.Values.provider == "capa"` to detect a CAPA EC2 based (non-EKS) cluster, and set reasonable values for the single-CIDR prototype (https://github.com/giantswarm/roadmap/issues/3183). There are open TODOs which will be completed with the full feature (https://github.com/giantswarm/roadmap/issues/2563), and then it should work like in vintage.

Plus minor fixes to Makefile/README.

### Checklist

- [x] Update changelog in CHANGELOG.md.
