### PR TITLE
Use SocketLB on host NS only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use SocketLB on host namespace only.
+
 ## [0.20.1] - 2024-02-27
 
 ### Changed

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -965,7 +965,7 @@ socketLB:
   enabled: false
 
   # -- Disable socket lb for non-root ns. This is used to enable Istio routing rules.
-  # hostNamespaceOnly: false
+  hostNamespaceOnly: true
 
 # -- Configure certificate generation for Hubble integration.
 # If hubble.tls.auto.method=cronJob, these values are used

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Revert helm schema and removal of nulls (#16)
-      sha: 6638023a0c8aeacf0d883dc4720be81394714cc0
+      commitTitle: Enable SocketLB only for hostNamespace (#15)...
+      sha: 0e53669d830a8e28af201c944d9dd84507650c44
       tags:
-      - 1.15.1-38-g6638023a0c
+      - 1.15.1-39-g0e53669d83
     path: cilium
   path: vendor
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -5,7 +5,7 @@ directories:
     contents:
       - path: cilium
         git:
-          url: https://github.com/giantswarm/cilium
+          url: https://github.com/giantswarm/cilium-upstream
           ref: "v1.15"
         includePaths:
           - install/kubernetes/cilium/**/*


### PR DESCRIPTION
SocketLB for pods are causing issues with connected UDP. In effect,
restarting our DNS servers breaks resolution on those apps that rely on
it.

We need this in place until https://github.com/cilium/cilium/issues/28820 is sorted out.

Signed-off-by: Matias Charriere <matias@giantswarm.io>

### Checklist

- [x] Update changelog in CHANGELOG.md.
