### PR TITLE
Add safe-to-evict annotations to Hubble Relay and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add safe-to-evict annotations to Hubble Relay and UI pods.
+
 ## [0.21.0] - 2024-02-29
 
 ### Added

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -1275,7 +1275,8 @@ hubble:
     annotations: {}
 
     # -- Annotations to be added to hubble-relay pods
-    podAnnotations: {}
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
     # -- Labels to be added to hubble-relay pods
     podLabels: {}
@@ -1545,7 +1546,8 @@ hubble:
     annotations: {}
 
     # -- Annotations to be added to hubble-ui pods
-    podAnnotations: {}
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
     # -- Labels to be added to hubble-ui pods
     podLabels: {}

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Enable SocketLB only for hostNamespace (#15)...
-      sha: 0e53669d830a8e28af201c944d9dd84507650c44
+      commitTitle: Add safe-to-evict annotations to Hubble Relay and UI (#18)...
+      sha: fd765921724555b37e0cfbc11ee97791413aa2ff
       tags:
-      - 1.15.1-39-g0e53669d83
+      - 1.15.1-41-gfd76592172
     path: cilium
   path: vendor
 - contents:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
This app is generated from the contents on [our cilium fork](https://github.com/giantswarm/cilium-upstream).
Manual changes to this repo will be lost the next time the app is generated from the fork.
If you need to change something, please do it on the fork, and then re-generate the app.
-->

This PR:

- add safe-to-evicts annotations, to allow clusterautoscaler to evict pods on deployments with only 1 replica.

Towards https://github.com/giantswarm/giantswarm/issues/29883

### Checklist

- [x] Update changelog in CHANGELOG.md.
