### PR TITLE
Add helm schema via vendir sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add safe-to-evict annotations to Hubble Relay and UI pods.
 
+### Added
+
+- Add helm values schema.
+
 ## [0.21.0] - 2024-02-29
 
 ### Added

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,7 +1,0 @@
-.PHONY: ensure-schema-gen
-ensure-schema-gen:
-	@helm schema-gen --help &>/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git
-
-.PHONY: schema-gen
-schema-gen: ensure-schema-gen ## Generates the values schema file
-	@cd helm/cilium && helm schema-gen values.yaml > values.schema.json

--- a/README.md
+++ b/README.md
@@ -42,12 +42,7 @@ We can apply our commits with
 git cherry-pick a4b22dee87ba3663f967f6dd6d8e666c849c742d^..25c449534cc325a5798fc7c839b8ac33591b3516
 ```
 
-It's probable that conflicts will happen, so we need to fix those when applying the commits.
-One last thing we need to do in our fork is to update the `values.schema.json` file, because upstream does not provide one. You can do it with
-```
-make schema-gen
-```
-
+It's probable that conflicts will happen, so we need to fix those when applying the commits. To update the charts `values.schema.json` and others, execute `make -C install/kubernetes` in the upstream repo.
 Don't forget to commit the changes, if any.
 Once we are done, we can push our new branch to our fork, and it will be ready to be used by `vendir` from here.
 

--- a/helm/cilium/README.md
+++ b/helm/cilium/README.md
@@ -211,8 +211,8 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.resources | object | `{}` | Resource requests and limits for the clustermesh-apiserver |
 | clustermesh.apiserver.securityContext | object | `{}` | Security context to be added to clustermesh-apiserver containers |
 | clustermesh.apiserver.service.annotations | object | `{}` | Annotations for the clustermesh-apiserver For GKE LoadBalancer, use annotation cloud.google.com/load-balancer-type: "Internal" For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0 |
-| clustermesh.apiserver.service.externalTrafficPolicy | string | `nil` | The externalTrafficPolicy of service used for apiserver access. |
-| clustermesh.apiserver.service.internalTrafficPolicy | string | `nil` | The internalTrafficPolicy of service used for apiserver access. |
+| clustermesh.apiserver.service.externalTrafficPolicy | string | `"Cluster"` | The externalTrafficPolicy of service used for apiserver access. |
+| clustermesh.apiserver.service.internalTrafficPolicy | string | `"Cluster"` | The internalTrafficPolicy of service used for apiserver access. |
 | clustermesh.apiserver.service.nodePort | int | `32379` | Optional port to use as the node port for apiserver access.  WARNING: make sure to configure a different NodePort in each cluster if kube-proxy replacement is enabled, as Cilium is currently affected by a known bug (#24692) when NodePorts are handled by the KPR implementation. If a service with the same NodePort exists both in the local and the remote cluster, all traffic originating from inside the cluster and targeting the corresponding NodePort will be redirected to a local backend, regardless of whether the destination node belongs to the local or the remote cluster. |
 | clustermesh.apiserver.service.type | string | `"NodePort"` | The type of service used for apiserver access. |
 | clustermesh.apiserver.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for the clustermesh-apiserver deployment |
@@ -477,7 +477,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
-| hubble.relay.podAnnotations | object | `{}` | Annotations to be added to hubble-relay pods |
+| hubble.relay.podAnnotations | object | `{"cluster-autoscaler.kubernetes.io/safe-to-evict":"true"}` | Annotations to be added to hubble-relay pods |
 | hubble.relay.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | hubble.relay.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | hubble.relay.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
@@ -547,7 +547,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"labels":{},"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
-| hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
+| hubble.ui.podAnnotations | object | `{"cluster-autoscaler.kubernetes.io/safe-to-evict":"true"}` | Annotations to be added to hubble-ui pods |
 | hubble.ui.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | hubble.ui.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | hubble.ui.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
@@ -569,7 +569,7 @@ contributors across the globe, there is almost always someone available to help.
 | identityAllocationMode | string | `"crd"` | Method to use for identity allocation (`crd` or `kvstore`). |
 | identityChangeGracePeriod | string | `"5s"` | Time to wait before using new identity on endpoint identity change. |
 | image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","registry":"gsoci.azurecr.io","repository":"giantswarm/cilium","tag":"v1.15.1","useDigest":false}` | Agent container image. |
-| imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
+| imagePullSecrets | list | `[]` | Configure image pull secrets for pulling container images |
 | ingressController.default | bool | `false` | Set cilium ingress controller to be the default ingress controller This will let cilium ingress controller route entries without ingress class set |
 | ingressController.defaultSecretName | string | `nil` | Default secret name for ingresses without .spec.tls[].secretName set. |
 | ingressController.defaultSecretNamespace | string | `nil` | Default secret namespace for ingresses without .spec.tls[].secretName set. |
@@ -786,8 +786,9 @@ contributors across the globe, there is almost always someone available to help.
 | serviceAccounts.nodeinit.enabled | bool | `false` | Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented. Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by this issue. Name and automount can be configured, if enabled is set to true. Otherwise, they are ignored. Enabled can be removed once the issue is fixed. Cilium-nodeinit DS must also be fixed. |
 | serviceNoBackendResponse | string | `"reject"` | Configure what the response should be to traffic for a service without backends. "reject" only works on kernels >= 5.10, on lower kernels we fallback to "drop". Possible values:  - reject (default)  - drop |
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
-| socketLB | object | `{"enabled":false}` | Configure socket LB |
+| socketLB | object | `{"enabled":false,"hostNamespaceOnly":true}` | Configure socket LB |
 | socketLB.enabled | bool | `false` | Enable socket LB |
+| socketLB.hostNamespaceOnly | bool | `true` | Disable socket lb for non-root ns. This is used to enable Istio routing rules. |
 | startupProbe.failureThreshold | int | `105` | failure threshold of startup probe. 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s) |
 | startupProbe.periodSeconds | int | `2` | interval between checks of the startup probe |
 | svcSourceRangeCheck | bool | `true` | Enable check of service source ranges (currently, only for LoadBalancer). |

--- a/helm/cilium/values.schema.json
+++ b/helm/cilium/values.schema.json
@@ -1,0 +1,5048 @@
+{
+  "properties": {
+    "MTU": {
+      "type": "integer"
+    },
+    "affinity": {
+      "properties": {
+        "podAntiAffinity": {
+          "properties": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "items": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "labelSelector": {
+                        "properties": {
+                          "matchLabels": {
+                            "properties": {
+                              "k8s-app": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "agent": {
+      "type": "boolean"
+    },
+    "agentNotReadyTaintKey": {
+      "type": "string"
+    },
+    "aksbyocni": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "alibabacloud": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "annotateK8sNode": {
+      "type": "boolean"
+    },
+    "annotations": {
+      "type": "object"
+    },
+    "apiRateLimit": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "authentication": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "gcInterval": {
+          "type": "string"
+        },
+        "mutual": {
+          "properties": {
+            "connectTimeout": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "spire": {
+              "properties": {
+                "adminSocketPath": {
+                  "type": "string"
+                },
+                "agentSocketPath": {
+                  "type": "string"
+                },
+                "annotations": {
+                  "type": "object"
+                },
+                "connectionTimeout": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "install": {
+                  "properties": {
+                    "agent": {
+                      "properties": {
+                        "affinity": {
+                          "type": "object"
+                        },
+                        "annotations": {
+                          "type": "object"
+                        },
+                        "image": {
+                          "properties": {
+                            "digest": {
+                              "type": "string"
+                            },
+                            "override": {
+                              "type": "string"
+                            },
+                            "pullPolicy": {
+                              "type": "string"
+                            },
+                            "repository": {
+                              "type": "string"
+                            },
+                            "tag": {
+                              "type": "string"
+                            },
+                            "useDigest": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "labels": {
+                          "type": "object"
+                        },
+                        "nodeSelector": {
+                          "type": "object"
+                        },
+                        "podSecurityContext": {
+                          "type": "object"
+                        },
+                        "securityContext": {
+                          "type": "object"
+                        },
+                        "serviceAccount": {
+                          "properties": {
+                            "create": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "skipKubeletVerification": {
+                          "type": "boolean"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "effect": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "effect": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "effect": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "effect": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "existingNamespace": {
+                      "type": "boolean"
+                    },
+                    "initImage": {
+                      "properties": {
+                        "digest": {
+                          "type": "string"
+                        },
+                        "override": {
+                          "type": "string"
+                        },
+                        "pullPolicy": {
+                          "type": "string"
+                        },
+                        "repository": {
+                          "type": "string"
+                        },
+                        "tag": {
+                          "type": "string"
+                        },
+                        "useDigest": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "server": {
+                      "properties": {
+                        "affinity": {
+                          "type": "object"
+                        },
+                        "annotations": {
+                          "type": "object"
+                        },
+                        "ca": {
+                          "properties": {
+                            "keyType": {
+                              "type": "string"
+                            },
+                            "subject": {
+                              "properties": {
+                                "commonName": {
+                                  "type": "string"
+                                },
+                                "country": {
+                                  "type": "string"
+                                },
+                                "organization": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "dataStorage": {
+                          "properties": {
+                            "accessMode": {
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "size": {
+                              "type": "string"
+                            },
+                            "storageClass": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "image": {
+                          "properties": {
+                            "digest": {
+                              "type": "string"
+                            },
+                            "override": {
+                              "type": "string"
+                            },
+                            "pullPolicy": {
+                              "type": "string"
+                            },
+                            "repository": {
+                              "type": "string"
+                            },
+                            "tag": {
+                              "type": "string"
+                            },
+                            "useDigest": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "initContainers": {
+                          "items": {},
+                          "type": "array"
+                        },
+                        "labels": {
+                          "type": "object"
+                        },
+                        "nodeSelector": {
+                          "type": "object"
+                        },
+                        "podSecurityContext": {
+                          "type": "object"
+                        },
+                        "securityContext": {
+                          "type": "object"
+                        },
+                        "service": {
+                          "properties": {
+                            "annotations": {
+                              "type": "object"
+                            },
+                            "labels": {
+                              "type": "object"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccount": {
+                          "properties": {
+                            "create": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "tolerations": {
+                          "items": {},
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "serverAddress": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "trustDomain": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "queueSize": {
+          "type": "integer"
+        },
+        "rotatedIdentitiesQueueSize": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "autoDirectNodeRoutes": {
+      "type": [
+        "boolean",
+        "string"
+      ]
+    },
+    "azure": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "bandwidthManager": {
+      "properties": {
+        "bbr": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "bgp": {
+      "properties": {
+        "announce": {
+          "properties": {
+            "loadbalancerIP": {
+              "type": "boolean"
+            },
+            "podCIDR": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "bgpControlPlane": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "secretsNamespace": {
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "bpf": {
+      "properties": {
+        "authMapMax": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "autoMount": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "ctAnyMax": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "ctTcpMax": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "hostLegacyRouting": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "lbExternalClusterIP": {
+          "type": "boolean"
+        },
+        "lbMapMax": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "mapDynamicSizeRatio": {
+          "type": [
+            "null",
+            "number"
+          ]
+        },
+        "masquerade": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "monitorAggregation": {
+          "type": "string"
+        },
+        "monitorFlags": {
+          "type": "string"
+        },
+        "monitorInterval": {
+          "type": "string"
+        },
+        "natMax": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "neighMax": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "policyMapMax": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "preallocateMaps": {
+          "type": "boolean"
+        },
+        "root": {
+          "type": "string"
+        },
+        "tproxy": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "vlanBypass": {
+          "type": [
+            "null",
+            "array"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "bpfClockProbe": {
+      "type": "boolean"
+    },
+    "certgen": {
+      "properties": {
+        "affinity": {
+          "type": "object"
+        },
+        "annotations": {
+          "properties": {
+            "cronJob": {
+              "type": "object"
+            },
+            "job": {
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "extraVolumeMounts": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumes": {
+          "items": {},
+          "type": "array"
+        },
+        "image": {
+          "properties": {
+            "override": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "tolerations": {
+          "items": {},
+          "type": "array"
+        },
+        "ttlSecondsAfterFinished": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "cgroup": {
+      "properties": {
+        "autoMount": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "resources": {
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "hostRoot": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "cleanBpfState": {
+      "type": "boolean"
+    },
+    "cleanState": {
+      "type": "boolean"
+    },
+    "cleanupKubeProxy": {
+      "type": "boolean"
+    },
+    "cluster": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "clustermesh": {
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "apiserver": {
+          "properties": {
+            "affinity": {
+              "properties": {
+                "podAntiAffinity": {
+                  "properties": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchLabels": {
+                                    "properties": {
+                                      "k8s-app": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "etcd": {
+              "properties": {
+                "init": {
+                  "properties": {
+                    "extraArgs": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "extraEnv": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "resources": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "lifecycle": {
+                  "type": "object"
+                },
+                "resources": {
+                  "type": "object"
+                },
+                "securityContext": {
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "extraArgs": {
+              "items": {},
+              "type": "array"
+            },
+            "extraEnv": {
+              "items": {},
+              "type": "array"
+            },
+            "extraVolumeMounts": {
+              "items": {},
+              "type": "array"
+            },
+            "extraVolumes": {
+              "items": {},
+              "type": "array"
+            },
+            "image": {
+              "properties": {
+                "digest": {
+                  "type": "string"
+                },
+                "override": {
+                  "type": "string"
+                },
+                "pullPolicy": {
+                  "type": "string"
+                },
+                "repository": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                },
+                "useDigest": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "kvstoremesh": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "extraArgs": {
+                  "items": {},
+                  "type": "array"
+                },
+                "extraEnv": {
+                  "items": {},
+                  "type": "array"
+                },
+                "extraVolumeMounts": {
+                  "items": {},
+                  "type": "array"
+                },
+                "lifecycle": {
+                  "type": "object"
+                },
+                "resources": {
+                  "type": "object"
+                },
+                "securityContext": {
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "type": "boolean"
+                    },
+                    "capabilities": {
+                      "properties": {
+                        "drop": {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "lifecycle": {
+              "type": "object"
+            },
+            "metrics": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "etcd": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "mode": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "kvstoremesh": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "port": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "port": {
+                  "type": "integer"
+                },
+                "serviceMonitor": {
+                  "properties": {
+                    "annotations": {
+                      "type": "object"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "etcd": {
+                      "properties": {
+                        "interval": {
+                          "type": "string"
+                        },
+                        "metricRelabelings": {
+                          "type": [
+                            "null",
+                            "array"
+                          ]
+                        },
+                        "relabelings": {
+                          "type": [
+                            "null",
+                            "array"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "interval": {
+                      "type": "string"
+                    },
+                    "kvstoremesh": {
+                      "properties": {
+                        "interval": {
+                          "type": "string"
+                        },
+                        "metricRelabelings": {
+                          "type": [
+                            "null",
+                            "array"
+                          ]
+                        },
+                        "relabelings": {
+                          "type": [
+                            "null",
+                            "array"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "type": "object"
+                    },
+                    "metricRelabelings": {
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "relabelings": {
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "nodeSelector": {
+              "properties": {
+                "kubernetes.io/os": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "podAnnotations": {
+              "type": "object"
+            },
+            "podDisruptionBudget": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "maxUnavailable": {
+                  "type": [
+                    "null",
+                    "integer",
+                    "string"
+                  ]
+                },
+                "minAvailable": {
+                  "type": [
+                    "null",
+                    "integer",
+                    "string"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "podLabels": {
+              "type": "object"
+            },
+            "podSecurityContext": {
+              "type": "object"
+            },
+            "priorityClassName": {
+              "type": "string"
+            },
+            "replicas": {
+              "type": "integer"
+            },
+            "resources": {
+              "type": "object"
+            },
+            "securityContext": {
+              "type": "object"
+            },
+            "service": {
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "externalTrafficPolicy": {
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ]
+                },
+                "internalTrafficPolicy": {
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ]
+                },
+                "nodePort": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "terminationGracePeriodSeconds": {
+              "type": "integer"
+            },
+            "tls": {
+              "properties": {
+                "admin": {
+                  "properties": {
+                    "cert": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "authMode": {
+                  "type": "string"
+                },
+                "auto": {
+                  "properties": {
+                    "certManagerIssuerRef": {
+                      "type": "object"
+                    },
+                    "certValidityDuration": {
+                      "type": "integer"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "method": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "client": {
+                  "properties": {
+                    "cert": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "remote": {
+                  "properties": {
+                    "cert": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "server": {
+                  "properties": {
+                    "cert": {
+                      "type": "string"
+                    },
+                    "extraDnsNames": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "extraIpAddresses": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "tolerations": {
+              "items": {},
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "items": {},
+              "type": "array"
+            },
+            "updateStrategy": {
+              "properties": {
+                "rollingUpdate": {
+                  "properties": {
+                    "maxUnavailable": {
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "config": {
+          "properties": {
+            "clusters": {
+              "items": {},
+              "type": "array"
+            },
+            "domain": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "maxConnectedClusters": {
+          "type": "integer"
+        },
+        "useAPIServer": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "cni": {
+      "properties": {
+        "binPath": {
+          "type": "string"
+        },
+        "chainingMode": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "chainingTarget": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "confFileMountPath": {
+          "type": "string"
+        },
+        "confPath": {
+          "type": "string"
+        },
+        "configMapKey": {
+          "type": "string"
+        },
+        "customConf": {
+          "type": "boolean"
+        },
+        "exclusive": {
+          "type": "boolean"
+        },
+        "hostConfDirMountPath": {
+          "type": "string"
+        },
+        "install": {
+          "type": "boolean"
+        },
+        "logFile": {
+          "type": "string"
+        },
+        "resources": {
+          "properties": {
+            "requests": {
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "uninstall": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "conntrackGCInterval": {
+      "type": "string"
+    },
+    "conntrackGCMaxInterval": {
+      "type": "string"
+    },
+    "containerRuntime": {
+      "properties": {
+        "integration": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "crdWaitTimeout": {
+      "type": "string"
+    },
+    "customCalls": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "daemon": {
+      "properties": {
+        "allowedConfigOverrides": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "blockedConfigOverrides": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "configSources": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "runPath": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "dashboards": {
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": "string"
+        },
+        "labelValue": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "debug": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "verbose": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "defaultPolicies": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "remove": {
+          "type": "boolean"
+        },
+        "tolerations": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "operator": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "disableEndpointCRD": {
+      "type": "boolean"
+    },
+    "dnsPolicy": {
+      "type": "string"
+    },
+    "dnsProxy": {
+      "properties": {
+        "dnsRejectResponseCode": {
+          "type": "string"
+        },
+        "enableDnsCompression": {
+          "type": "boolean"
+        },
+        "endpointMaxIpPerHostname": {
+          "type": "integer"
+        },
+        "idleConnectionGracePeriod": {
+          "type": "string"
+        },
+        "maxDeferredConnectionDeletes": {
+          "type": "integer"
+        },
+        "minTtl": {
+          "type": "integer"
+        },
+        "preCache": {
+          "type": "string"
+        },
+        "proxyPort": {
+          "type": "integer"
+        },
+        "proxyResponseMaxDelay": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "egressGateway": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "installRoutes": {
+          "type": "boolean"
+        },
+        "reconciliationTriggerInterval": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "eksMode": {
+      "type": "boolean"
+    },
+    "enableCiliumEndpointSlice": {
+      "type": "boolean"
+    },
+    "enableCriticalPriorityClass": {
+      "type": "boolean"
+    },
+    "enableIPv4BIGTCP": {
+      "type": "boolean"
+    },
+    "enableIPv4Masquerade": {
+      "type": "boolean"
+    },
+    "enableIPv6BIGTCP": {
+      "type": "boolean"
+    },
+    "enableIPv6Masquerade": {
+      "type": "boolean"
+    },
+    "enableK8sTerminatingEndpoint": {
+      "type": "boolean"
+    },
+    "enableMasqueradeRouteSource": {
+      "type": "boolean"
+    },
+    "enableRuntimeDeviceDetection": {
+      "type": "boolean"
+    },
+    "enableXTSocketFallback": {
+      "type": "boolean"
+    },
+    "encryption": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "interface": {
+          "type": "string"
+        },
+        "ipsec": {
+          "properties": {
+            "interface": {
+              "type": "string"
+            },
+            "keyFile": {
+              "type": "string"
+            },
+            "keyRotationDuration": {
+              "type": "string"
+            },
+            "keyWatcher": {
+              "type": "boolean"
+            },
+            "mountPath": {
+              "type": "string"
+            },
+            "secretName": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "keyFile": {
+          "type": "string"
+        },
+        "mountPath": {
+          "type": "string"
+        },
+        "nodeEncryption": {
+          "type": "boolean"
+        },
+        "secretName": {
+          "type": "string"
+        },
+        "strictMode": {
+          "properties": {
+            "allowRemoteNodeIdentities": {
+              "type": "boolean"
+            },
+            "cidr": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "type": {
+          "type": "string"
+        },
+        "wireguard": {
+          "properties": {
+            "persistentKeepalive": {
+              "type": "string"
+            },
+            "userspaceFallback": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "endpointHealthChecking": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "endpointRoutes": {
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "string"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "endpointStatus": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "eni": {
+      "properties": {
+        "awsEnablePrefixDelegation": {
+          "type": "boolean"
+        },
+        "awsReleaseExcessIPs": {
+          "type": "boolean"
+        },
+        "ec2APIEndpoint": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "eniTags": {
+          "type": "object"
+        },
+        "gcInterval": {
+          "type": "string"
+        },
+        "gcTags": {
+          "type": "object"
+        },
+        "iamRole": {
+          "type": "string"
+        },
+        "instanceTagsFilter": {
+          "items": {},
+          "type": "array"
+        },
+        "subnetIDsFilter": {
+          "items": {},
+          "type": "array"
+        },
+        "subnetTagsFilter": {
+          "items": {},
+          "type": "array"
+        },
+        "updateEC2AdapterLimitViaAPI": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "envoy": {
+      "properties": {
+        "affinity": {
+          "properties": {
+            "podAntiAffinity": {
+              "properties": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchLabels": {
+                                "properties": {
+                                  "k8s-app": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "connectTimeoutSeconds": {
+          "type": "integer"
+        },
+        "dnsPolicy": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "extraArgs": {
+          "items": {},
+          "type": "array"
+        },
+        "extraContainers": {
+          "items": {},
+          "type": "array"
+        },
+        "extraEnv": {
+          "items": {},
+          "type": "array"
+        },
+        "extraHostPathMounts": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumes": {
+          "items": {},
+          "type": "array"
+        },
+        "healthPort": {
+          "type": "integer"
+        },
+        "idleTimeoutDurationSeconds": {
+          "type": "integer"
+        },
+        "image": {
+          "properties": {
+            "digest": {
+              "type": "string"
+            },
+            "override": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "useDigest": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "livenessProbe": {
+          "properties": {
+            "failureThreshold": {
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "log": {
+          "properties": {
+            "format": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "maxConnectionDurationSeconds": {
+          "type": "integer"
+        },
+        "maxRequestsPerConnection": {
+          "type": "integer"
+        },
+        "nodeSelector": {
+          "properties": {
+            "kubernetes.io/os": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "priorityClassName": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "prometheus": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "port": {
+              "type": "string"
+            },
+            "serviceMonitor": {
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "type": "string"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "metricRelabelings": {
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "relabelings": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "replacement": {
+                            "type": "string"
+                          },
+                          "sourceLabels": {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          },
+                          "targetLabel": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "readinessProbe": {
+          "properties": {
+            "failureThreshold": {
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "resources": {
+          "type": "object"
+        },
+        "rollOutPods": {
+          "type": "boolean"
+        },
+        "securityContext": {
+          "properties": {
+            "capabilities": {
+              "properties": {
+                "envoy": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "privileged": {
+              "type": "boolean"
+            },
+            "seLinuxOptions": {
+              "properties": {
+                "level": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "startupProbe": {
+          "properties": {
+            "failureThreshold": {
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer"
+        },
+        "tolerations": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "operator": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "updateStrategy": {
+          "properties": {
+            "rollingUpdate": {
+              "properties": {
+                "maxUnavailable": {
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "envoyConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "secretsNamespace": {
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "etcd": {
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "clusterDomain": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "endpoints": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "extraArgs": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumes": {
+          "items": {},
+          "type": "array"
+        },
+        "image": {
+          "properties": {
+            "override": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "k8sService": {
+          "type": "boolean"
+        },
+        "nodeSelector": {
+          "properties": {
+            "kubernetes.io/os": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podDisruptionBudget": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "maxUnavailable": {
+              "type": [
+                "null",
+                "integer",
+                "string"
+              ]
+            },
+            "minAvailable": {
+              "type": [
+                "null",
+                "integer",
+                "string"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "ssl": {
+          "type": "boolean"
+        },
+        "tolerations": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "operator": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "items": {},
+          "type": "array"
+        },
+        "updateStrategy": {
+          "properties": {
+            "rollingUpdate": {
+              "properties": {
+                "maxSurge": {
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                },
+                "maxUnavailable": {
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "externalIPs": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "externalWorkloads": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "extraArgs": {
+      "items": {},
+      "type": "array"
+    },
+    "extraConfig": {
+      "type": "object"
+    },
+    "extraContainers": {
+      "items": {},
+      "type": "array"
+    },
+    "extraEnv": {
+      "items": {},
+      "type": "array"
+    },
+    "extraHostPathMounts": {
+      "items": {},
+      "type": "array"
+    },
+    "extraPolicies": {
+      "properties": {
+        "allowEgressToCoreDNS": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "namespaces": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "allowEgressToProxy": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "httpProxy": {
+              "type": "string"
+            },
+            "httpsProxy": {
+              "type": "string"
+            },
+            "namespaces": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "tolerations": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "operator": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "extraVolumeMounts": {
+      "items": {},
+      "type": "array"
+    },
+    "extraVolumes": {
+      "items": {},
+      "type": "array"
+    },
+    "gatewayAPI": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "secretsNamespace": {
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "sync": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "gke": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "global": {
+      "properties": {
+        "podSecurityStandards": {
+          "properties": {
+            "enforced": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "healthChecking": {
+      "type": "boolean"
+    },
+    "healthPort": {
+      "type": "integer"
+    },
+    "highScaleIPcache": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "hostFirewall": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "hostPort": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "hubble": {
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "export": {
+          "properties": {
+            "dynamic": {
+              "properties": {
+                "config": {
+                  "properties": {
+                    "configMapName": {
+                      "type": "string"
+                    },
+                    "content": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "properties": {
+                              "excludeFilters": {
+                                "items": {},
+                                "type": "array"
+                              },
+                              "fieldMask": {
+                                "items": {},
+                                "type": "array"
+                              },
+                              "filePath": {
+                                "type": "string"
+                              },
+                              "includeFilters": {
+                                "items": {},
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "createConfigMap": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "fileMaxBackups": {
+              "type": "integer"
+            },
+            "fileMaxSizeMb": {
+              "type": "integer"
+            },
+            "static": {
+              "properties": {
+                "allowList": {
+                  "items": {},
+                  "type": "array"
+                },
+                "denyList": {
+                  "items": {},
+                  "type": "array"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "fieldMask": {
+                  "items": {},
+                  "type": "array"
+                },
+                "filePath": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "listenAddress": {
+          "type": "string"
+        },
+        "metrics": {
+          "properties": {
+            "dashboards": {
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "labelValue": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "enableOpenMetrics": {
+              "type": "boolean"
+            },
+            "enabled": {
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "port": {
+              "type": "integer"
+            },
+            "serviceAnnotations": {
+              "type": "object"
+            },
+            "serviceMonitor": {
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "type": "string"
+                },
+                "jobLabel": {
+                  "type": "string"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "metricRelabelings": {
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "relabelings": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "replacement": {
+                            "type": "string"
+                          },
+                          "sourceLabels": {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          },
+                          "targetLabel": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "peerService": {
+          "properties": {
+            "clusterDomain": {
+              "type": "string"
+            },
+            "targetPort": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "preferIpv6": {
+          "type": "boolean"
+        },
+        "redact": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "http": {
+              "properties": {
+                "headers": {
+                  "properties": {
+                    "allow": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "deny": {
+                      "items": {},
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "urlQuery": {
+                  "type": "boolean"
+                },
+                "userInfo": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "kafka": {
+              "properties": {
+                "apiKey": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "relay": {
+          "properties": {
+            "affinity": {
+              "properties": {
+                "podAffinity": {
+                  "properties": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchLabels": {
+                                    "properties": {
+                                      "k8s-app": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "annotations": {
+              "type": "object"
+            },
+            "dialTimeout": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "extraEnv": {
+              "items": {},
+              "type": "array"
+            },
+            "extraVolumeMounts": {
+              "items": {},
+              "type": "array"
+            },
+            "extraVolumes": {
+              "items": {},
+              "type": "array"
+            },
+            "gops": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "port": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "image": {
+              "properties": {
+                "digest": {
+                  "type": "string"
+                },
+                "override": {
+                  "type": "string"
+                },
+                "pullPolicy": {
+                  "type": "string"
+                },
+                "repository": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                },
+                "useDigest": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "listenHost": {
+              "type": "string"
+            },
+            "listenPort": {
+              "type": "string"
+            },
+            "nodeSelector": {
+              "properties": {
+                "kubernetes.io/os": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "podAnnotations": {
+              "properties": {
+                "cluster-autoscaler.kubernetes.io/safe-to-evict": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "podDisruptionBudget": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "maxUnavailable": {
+                  "type": [
+                    "null",
+                    "integer",
+                    "string"
+                  ]
+                },
+                "minAvailable": {
+                  "type": [
+                    "null",
+                    "integer",
+                    "string"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "podLabels": {
+              "type": "object"
+            },
+            "podSecurityContext": {
+              "properties": {
+                "fsGroup": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "pprof": {
+              "properties": {
+                "address": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "port": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "priorityClassName": {
+              "type": "string"
+            },
+            "prometheus": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "port": {
+                  "type": "integer"
+                },
+                "serviceMonitor": {
+                  "properties": {
+                    "annotations": {
+                      "type": "object"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "interval": {
+                      "type": "string"
+                    },
+                    "labels": {
+                      "type": "object"
+                    },
+                    "metricRelabelings": {
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "relabelings": {
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "replicas": {
+              "type": "integer"
+            },
+            "resources": {
+              "type": "object"
+            },
+            "retryTimeout": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "rollOutPods": {
+              "type": "boolean"
+            },
+            "securityContext": {
+              "properties": {
+                "capabilities": {
+                  "properties": {
+                    "drop": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "runAsGroup": {
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "service": {
+              "properties": {
+                "nodePort": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "sortBufferDrainTimeout": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "sortBufferLenMax": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "terminationGracePeriodSeconds": {
+              "type": "integer"
+            },
+            "tls": {
+              "properties": {
+                "client": {
+                  "properties": {
+                    "cert": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "server": {
+                  "properties": {
+                    "cert": {
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "extraDnsNames": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "extraIpAddresses": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "key": {
+                      "type": "string"
+                    },
+                    "mtls": {
+                      "type": "boolean"
+                    },
+                    "relayName": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "tolerations": {
+              "items": {},
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "items": {},
+              "type": "array"
+            },
+            "updateStrategy": {
+              "properties": {
+                "rollingUpdate": {
+                  "properties": {
+                    "maxUnavailable": {
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "skipUnknownCGroupIDs": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "socketPath": {
+          "type": "string"
+        },
+        "tls": {
+          "properties": {
+            "auto": {
+              "properties": {
+                "certManagerIssuerRef": {
+                  "type": "object"
+                },
+                "certValidityDuration": {
+                  "type": "integer"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "method": {
+                  "type": "string"
+                },
+                "schedule": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "server": {
+              "properties": {
+                "cert": {
+                  "type": "string"
+                },
+                "extraDnsNames": {
+                  "items": {},
+                  "type": "array"
+                },
+                "extraIpAddresses": {
+                  "items": {},
+                  "type": "array"
+                },
+                "key": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "ui": {
+          "properties": {
+            "affinity": {
+              "type": "object"
+            },
+            "annotations": {
+              "type": "object"
+            },
+            "backend": {
+              "properties": {
+                "extraEnv": {
+                  "items": {},
+                  "type": "array"
+                },
+                "extraVolumeMounts": {
+                  "items": {},
+                  "type": "array"
+                },
+                "extraVolumes": {
+                  "items": {},
+                  "type": "array"
+                },
+                "image": {
+                  "properties": {
+                    "digest": {
+                      "type": "string"
+                    },
+                    "override": {
+                      "type": "string"
+                    },
+                    "pullPolicy": {
+                      "type": "string"
+                    },
+                    "repository": {
+                      "type": "string"
+                    },
+                    "tag": {
+                      "type": "string"
+                    },
+                    "useDigest": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                },
+                "livenessProbe": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                },
+                "readinessProbe": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                },
+                "resources": {
+                  "type": "object"
+                },
+                "securityContext": {
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "baseUrl": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "frontend": {
+              "properties": {
+                "extraEnv": {
+                  "items": {},
+                  "type": "array"
+                },
+                "extraVolumeMounts": {
+                  "items": {},
+                  "type": "array"
+                },
+                "extraVolumes": {
+                  "items": {},
+                  "type": "array"
+                },
+                "image": {
+                  "properties": {
+                    "digest": {
+                      "type": "string"
+                    },
+                    "override": {
+                      "type": "string"
+                    },
+                    "pullPolicy": {
+                      "type": "string"
+                    },
+                    "repository": {
+                      "type": "string"
+                    },
+                    "tag": {
+                      "type": "string"
+                    },
+                    "useDigest": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                },
+                "resources": {
+                  "type": "object"
+                },
+                "securityContext": {
+                  "type": "object"
+                },
+                "server": {
+                  "properties": {
+                    "ipv6": {
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "ingress": {
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "className": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "hosts": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "tls": {
+                  "items": {},
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "nodeSelector": {
+              "properties": {
+                "kubernetes.io/os": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "podAnnotations": {
+              "properties": {
+                "cluster-autoscaler.kubernetes.io/safe-to-evict": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "podDisruptionBudget": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "maxUnavailable": {
+                  "type": [
+                    "null",
+                    "integer",
+                    "string"
+                  ]
+                },
+                "minAvailable": {
+                  "type": [
+                    "null",
+                    "integer",
+                    "string"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "podLabels": {
+              "type": "object"
+            },
+            "priorityClassName": {
+              "type": "string"
+            },
+            "replicas": {
+              "type": "integer"
+            },
+            "rollOutPods": {
+              "type": "boolean"
+            },
+            "securityContext": {
+              "properties": {
+                "fsGroup": {
+                  "type": "integer"
+                },
+                "runAsGroup": {
+                  "type": "integer"
+                },
+                "runAsUser": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "service": {
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "nodePort": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "standalone": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "tls": {
+                  "properties": {
+                    "certsVolume": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "tls": {
+              "properties": {
+                "client": {
+                  "properties": {
+                    "cert": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "tolerations": {
+              "items": {},
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "items": {},
+              "type": "array"
+            },
+            "updateStrategy": {
+              "properties": {
+                "rollingUpdate": {
+                  "properties": {
+                    "maxUnavailable": {
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "identityAllocationMode": {
+      "type": "string"
+    },
+    "identityChangeGracePeriod": {
+      "type": "string"
+    },
+    "image": {
+      "properties": {
+        "digest": {
+          "type": "string"
+        },
+        "override": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        },
+        "registry": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "useDigest": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "imagePullSecrets": {
+      "items": {},
+      "type": "array"
+    },
+    "ingressController": {
+      "properties": {
+        "default": {
+          "type": "boolean"
+        },
+        "defaultSecretName": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "defaultSecretNamespace": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "enableProxyProtocol": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "enforceHttps": {
+          "type": "boolean"
+        },
+        "ingressLBAnnotationPrefixes": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "loadbalancerMode": {
+          "type": "string"
+        },
+        "secretsNamespace": {
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "sync": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "service": {
+          "properties": {
+            "allocateLoadBalancerNodePorts": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "annotations": {
+              "type": "object"
+            },
+            "insecureNodePort": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "labels": {
+              "type": "object"
+            },
+            "loadBalancerClass": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "loadBalancerIP": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "secureNodePort": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "initResources": {
+      "type": "object"
+    },
+    "installNoConntrackIptablesRules": {
+      "type": "boolean"
+    },
+    "ipMasqAgent": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ipam": {
+      "properties": {
+        "ciliumNodeUpdateRate": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "operator": {
+          "properties": {
+            "autoCreateCiliumPodIPPools": {
+              "type": "object"
+            },
+            "clusterPoolIPv4MaskSize": {
+              "type": "integer"
+            },
+            "clusterPoolIPv4PodCIDRList": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": [
+                "array",
+                "string"
+              ]
+            },
+            "clusterPoolIPv6MaskSize": {
+              "type": "integer"
+            },
+            "clusterPoolIPv6PodCIDRList": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": [
+                "array",
+                "string"
+              ]
+            },
+            "externalAPILimitBurstSize": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "externalAPILimitQPS": {
+              "type": [
+                "null",
+                "number"
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ipv4": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ipv4NativeRoutingCIDR": {
+      "type": "string"
+    },
+    "ipv6": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ipv6NativeRoutingCIDR": {
+      "type": "string"
+    },
+    "k8s": {
+      "type": "object"
+    },
+    "k8sClientRateLimit": {
+      "properties": {
+        "burst": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "qps": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "k8sNetworkPolicy": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "k8sServiceHost": {
+      "type": "string"
+    },
+    "k8sServicePort": {
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "keepDeprecatedLabels": {
+      "type": "boolean"
+    },
+    "keepDeprecatedProbes": {
+      "type": "boolean"
+    },
+    "kubeConfigPath": {
+      "type": "string"
+    },
+    "kubeProxyReplacementHealthzBindAddr": {
+      "type": "string"
+    },
+    "l2NeighDiscovery": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "refreshPeriod": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "l2announcements": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "l2podAnnouncements": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "interface": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "l7Proxy": {
+      "type": "boolean"
+    },
+    "labels": {
+      "type": "string"
+    },
+    "livenessProbe": {
+      "properties": {
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "loadBalancer": {
+      "properties": {
+        "acceleration": {
+          "type": "string"
+        },
+        "l7": {
+          "properties": {
+            "algorithm": {
+              "type": "string"
+            },
+            "backend": {
+              "type": "string"
+            },
+            "ports": {
+              "items": {},
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "localRedirectPolicy": {
+      "type": "boolean"
+    },
+    "logSystemLoad": {
+      "type": "boolean"
+    },
+    "maglev": {
+      "type": "object"
+    },
+    "monitor": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "name": {
+      "type": "string"
+    },
+    "nat46x64Gateway": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "nodePort": {
+      "properties": {
+        "autoProtectPortRange": {
+          "type": "boolean"
+        },
+        "bindProtection": {
+          "type": "boolean"
+        },
+        "enableHealthCheck": {
+          "type": "boolean"
+        },
+        "enableHealthCheckLoadBalancerIP": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "nodeSelector": {
+      "properties": {
+        "kubernetes.io/os": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "nodeinit": {
+      "properties": {
+        "affinity": {
+          "type": "object"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "bootstrapFile": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "extraEnv": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumes": {
+          "items": {},
+          "type": "array"
+        },
+        "image": {
+          "properties": {
+            "override": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "nodeSelector": {
+          "properties": {
+            "kubernetes.io/os": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "prestop": {
+          "properties": {
+            "postScript": {
+              "type": "string"
+            },
+            "preScript": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "resources": {
+          "properties": {
+            "requests": {
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "securityContext": {
+          "properties": {
+            "capabilities": {
+              "properties": {
+                "add": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "privileged": {
+              "type": "boolean"
+            },
+            "seLinuxOptions": {
+              "properties": {
+                "level": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "startup": {
+          "properties": {
+            "postScript": {
+              "type": "string"
+            },
+            "preScript": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "tolerations": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "operator": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "updateStrategy": {
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "operator": {
+      "properties": {
+        "affinity": {
+          "properties": {
+            "podAntiAffinity": {
+              "properties": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchLabels": {
+                                "properties": {
+                                  "io.cilium/app": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "dashboards": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "label": {
+              "type": "string"
+            },
+            "labelValue": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "dnsPolicy": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "endpointGCInterval": {
+          "type": "string"
+        },
+        "extraArgs": {
+          "items": {},
+          "type": "array"
+        },
+        "extraEnv": {
+          "items": {},
+          "type": "array"
+        },
+        "extraHostPathMounts": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumes": {
+          "items": {},
+          "type": "array"
+        },
+        "identityGCInterval": {
+          "type": "string"
+        },
+        "identityHeartbeatTimeout": {
+          "type": "string"
+        },
+        "image": {
+          "properties": {
+            "alibabacloudDigest": {
+              "type": "string"
+            },
+            "awsDigest": {
+              "type": "string"
+            },
+            "azureDigest": {
+              "type": "string"
+            },
+            "genericDigest": {
+              "type": "string"
+            },
+            "override": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "suffix": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "useDigest": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "nodeGCInterval": {
+          "type": "string"
+        },
+        "nodeSelector": {
+          "properties": {
+            "kubernetes.io/os": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podDisruptionBudget": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "maxUnavailable": {
+              "type": [
+                "null",
+                "integer",
+                "string"
+              ]
+            },
+            "minAvailable": {
+              "type": [
+                "null",
+                "integer",
+                "string"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "pprof": {
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "port": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "prometheus": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "serviceMonitor": {
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "type": "string"
+                },
+                "jobLabel": {
+                  "type": "string"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "metricRelabelings": {
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "relabelings": {
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "removeNodeTaints": {
+          "type": "boolean"
+        },
+        "replicas": {
+          "type": "integer"
+        },
+        "resources": {
+          "type": "object"
+        },
+        "rollOutPods": {
+          "type": "boolean"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "setNodeNetworkStatus": {
+          "type": "boolean"
+        },
+        "setNodeTaints": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "skipCNPStatusStartupClean": {
+          "type": "boolean"
+        },
+        "skipCRDCreation": {
+          "type": "boolean"
+        },
+        "tolerations": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "operator": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "items": {},
+          "type": "array"
+        },
+        "unmanagedPodWatcher": {
+          "properties": {
+            "intervalSeconds": {
+              "type": "integer"
+            },
+            "restart": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "updateStrategy": {
+          "properties": {
+            "rollingUpdate": {
+              "properties": {
+                "maxSurge": {
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                },
+                "maxUnavailable": {
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "pmtuDiscovery": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "policyCIDRMatchMode": {
+      "type": [
+        "null",
+        "string",
+        "array"
+      ]
+    },
+    "policyEnforcementMode": {
+      "type": "string"
+    },
+    "pprof": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "preflight": {
+      "properties": {
+        "affinity": {
+          "properties": {
+            "podAffinity": {
+              "properties": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchLabels": {
+                                "properties": {
+                                  "k8s-app": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "extraEnv": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "items": {},
+          "type": "array"
+        },
+        "extraVolumes": {
+          "items": {},
+          "type": "array"
+        },
+        "image": {
+          "properties": {
+            "digest": {
+              "type": "string"
+            },
+            "override": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "useDigest": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "nodeSelector": {
+          "properties": {
+            "kubernetes.io/os": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podDisruptionBudget": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "maxUnavailable": {
+              "type": [
+                "null",
+                "integer",
+                "string"
+              ]
+            },
+            "minAvailable": {
+              "type": [
+                "null",
+                "integer",
+                "string"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer"
+        },
+        "tofqdnsPreCache": {
+          "type": "string"
+        },
+        "tolerations": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "effect": {
+                    "type": "string"
+                  },
+                  "key": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "effect": {
+                    "type": "string"
+                  },
+                  "key": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "effect": {
+                    "type": "string"
+                  },
+                  "key": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "effect": {
+                    "type": "string"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "operator": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "updateStrategy": {
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "validateCNPs": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "prometheus": {
+      "properties": {
+        "controllerGroupMetrics": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "metrics": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "type": [
+            "null",
+            "array"
+          ]
+        },
+        "port": {
+          "type": "integer"
+        },
+        "serviceMonitor": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "jobLabel": {
+              "type": "string"
+            },
+            "labels": {
+              "type": "object"
+            },
+            "metricRelabelings": {
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "relabelings": {
+              "items": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "replacement": {
+                        "type": "string"
+                      },
+                      "sourceLabels": {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      "targetLabel": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            "trustCRDsExist": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "proxy": {
+      "properties": {
+        "prometheus": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "port": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "sidecarImageRegex": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "rbac": {
+      "properties": {
+        "create": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "readinessProbe": {
+      "properties": {
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "remoteNodeIdentity": {
+      "type": "boolean"
+    },
+    "resourceQuotas": {
+      "properties": {
+        "cilium": {
+          "properties": {
+            "hard": {
+              "properties": {
+                "pods": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "operator": {
+          "properties": {
+            "hard": {
+              "properties": {
+                "pods": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "resources": {
+      "type": "object"
+    },
+    "rollOutCiliumPods": {
+      "type": "boolean"
+    },
+    "routingMode": {
+      "type": "string"
+    },
+    "sctp": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "securityContext": {
+      "properties": {
+        "capabilities": {
+          "properties": {
+            "applySysctlOverwrites": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            "ciliumAgent": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            "cleanCiliumState": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            "mountCgroup": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "privileged": {
+          "type": "boolean"
+        },
+        "seLinuxOptions": {
+          "properties": {
+            "level": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "serviceAccounts": {
+      "properties": {
+        "cilium": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "clustermeshApiserver": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "clustermeshcertgen": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "defaultPolicies": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "envoy": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "etcd": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "extraPolicies": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "hubblecertgen": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "nodeinit": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "operator": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "preflight": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "relay": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "ui": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "automount": {
+              "type": "boolean"
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "serviceNoBackendResponse": {
+      "type": "string"
+    },
+    "sleepAfterInit": {
+      "type": "boolean"
+    },
+    "socketLB": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "hostNamespaceOnly": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "startupProbe": {
+      "properties": {
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "svcSourceRangeCheck": {
+      "type": "boolean"
+    },
+    "synchronizeK8sNodes": {
+      "type": "boolean"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer"
+    },
+    "tls": {
+      "properties": {
+        "ca": {
+          "properties": {
+            "cert": {
+              "type": "string"
+            },
+            "certValidityDuration": {
+              "type": "integer"
+            },
+            "key": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "caBundle": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "key": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "useSecret": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "secretsBackend": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tolerations": {
+      "items": {
+        "anyOf": [
+          {
+            "properties": {
+              "operator": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "tunnelPort": {
+      "type": "integer"
+    },
+    "tunnelProtocol": {
+      "type": "string"
+    },
+    "updateStrategy": {
+      "properties": {
+        "rollingUpdate": {
+          "properties": {
+            "maxUnavailable": {
+              "type": [
+                "integer",
+                "string"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "vtep": {
+      "properties": {
+        "cidr": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "mac": {
+          "type": "string"
+        },
+        "mask": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "waitForKubeProxy": {
+      "type": "boolean"
+    },
+    "wellKnownIdentities": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -11,6 +11,9 @@
 debug:
   # -- Enable debug logging
   enabled: false
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Configure verbosity levels for debug logging
   # This option is used to enable debug messages for operations related to such
   # sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is
@@ -30,7 +33,7 @@ rbac:
   create: true
 
 # -- Configure image pull secrets for pulling container images
-imagePullSecrets:
+imagePullSecrets: []
 # - name: "image-pull-secret"
 
 # -- (string) Kubernetes config path
@@ -38,6 +41,9 @@ imagePullSecrets:
 kubeConfigPath: ""
 # -- (string) Kubernetes service host
 k8sServiceHost: ""
+# @schema
+# type: [string, integer]
+# @schema
 # -- (string) Kubernetes service port
 k8sServicePort: ""
 
@@ -47,9 +53,15 @@ k8sServicePort: ""
 # rate limit, the agent and operator will start to throttle requests by delaying
 # them until there is budget or the request times out.
 k8sClientRateLimit:
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) The sustained request rate in requests per second.
   # @default -- 5 for k8s up to 1.26. 10 for k8s version 1.27+
   qps:
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) The burst request rate in requests per second.
   # The rate limiter will allow short bursts with a higher rate.
   # @default -- 10 for k8s up to 1.26. 20 for k8s version 1.27+
@@ -335,6 +347,9 @@ securityContext:
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
+    # @schema
+    # type: [integer, string]
+    # @schema
     maxUnavailable: 2
 
 # Configuration Values for cilium-agent
@@ -345,6 +360,9 @@ aksbyocni:
   # use Azure integration (`azure.enabled`) instead.
   enabled: false
 
+# @schema
+# type: [boolean, string]
+# @schema
 # -- Enable installation of PodCIDR routes between worker
 # nodes if worker nodes share a common L2 network segment.
 autoDirectNodeRoutes: false
@@ -452,35 +470,59 @@ bpf:
   # memory usage but can reduce latency.
   preallocateMaps: false
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries in auth map.
   # @default -- `524288`
   authMapMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries in the TCP connection tracking
   # table.
   # @default -- `524288`
   ctTcpMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries for the non-TCP connection
   # tracking table.
   # @default -- `262144`
   ctAnyMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Configure the maximum number of service entries in the
   # load balancer maps.
   lbMapMax: 65536
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries for the NAT table.
   # @default -- `524288`
   natMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries for the neighbor table.
   # @default -- `524288`
   neighMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
   policyMapMax: 16384
 
+  # @schema
+  # type: [null, number]
+  # @schema
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
   # @default -- `0.0025`
@@ -501,10 +543,16 @@ bpf:
   # -- Allow cluster external access to ClusterIP services.
   lbExternalClusterIP: false
 
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- (bool) Enable native IP masquerade support in eBPF
   # @default -- `false`
   masquerade: ~
 
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- (bool) Configure whether direct routing mode should route traffic via
   # host stack (true) or directly and more efficiently out of BPF (false) if
   # the kernel supports it. The latter has the implication that it will also
@@ -512,11 +560,17 @@ bpf:
   # @default -- `false`
   hostLegacyRouting: ~
 
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- (bool) Configure the eBPF-based TPROXY to reduce reliance on iptables rules
   # for implementing Layer 7 policy.
   # @default -- `false`
   tproxy: ~
 
+  # @schema
+  # type: [null, array]
+  # @schema
   # -- (list) Configure explicitly allowed VLAN id's for bpf logic bypass.
   # [0] will allow all VLAN id's without any filtering.
   # @default -- `[]`
@@ -553,6 +607,9 @@ cni:
   # nodes to go unmanageable.
   uninstall: false
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Configure chaining on top of other CNI plugins. Possible values:
   #  - none
   #  - aws-cni
@@ -561,6 +618,9 @@ cni:
   #  - portmap
   chainingMode: ~
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- A CNI network name in to which the Cilium plugin should be added as a chained plugin.
   # This will cause the agent to watch for a CNI network with this network name. When it is
   # found, this will be used as the basis for Cilium's CNI configuration file. If this is
@@ -650,12 +710,18 @@ daemon:
   # -- Configure where Cilium runtime state should be stored.
   runPath: "/var/run/cilium"
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Configure a custom list of possible configuration override sources
   # The default is "config-map:cilium-config,cilium-node-config". For supported
   # values, see the help text for the build-config subcommand.
   # Note that this value should be a comma-separated string.
   configSources: ~
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- allowedConfigOverrides is a list of config-map keys that can be overridden.
   # That is to say, if this value is set, config sources (excepting the first one) can
   # only override keys in this list.
@@ -666,6 +732,9 @@ daemon:
   # change the configSources variable.
   allowedConfigOverrides: ~
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- blockedConfigOverrides is a list of config-map keys that may not be overridden.
   # In other words, if any of these keys appear in a configuration source excepting the
   # first one, they will be ignored
@@ -741,9 +810,15 @@ ingressController:
   # -- IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service
   ingressLBAnnotationPrefixes: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Default secret namespace for ingresses without .spec.tls[].secretName set.
   defaultSecretNamespace:
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Default secret name for ingresses without .spec.tls[].secretName set.
   defaultSecretName:
 
@@ -770,14 +845,29 @@ ingressController:
     annotations: {}
     # -- Service type for the shared LB service
     type: LoadBalancer
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- Configure a specific nodePort for insecure HTTP traffic on the shared LB service
     insecureNodePort: ~
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- Configure a specific nodePort for secure HTTPS traffic on the shared LB service
     secureNodePort : ~
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+)
     loadBalancerClass: ~
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- Configure a specific loadBalancerIP on the shared LB service
     loadBalancerIP : ~
+    # @schema
+    # type: [null, boolean]
+    # @schema
     # -- Configure if node port allocation is required for LB service
     # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
     allocateLoadBalancerNodePorts: ~
@@ -886,6 +976,9 @@ endpointStatus:
   status: ""
 
 endpointRoutes:
+  # @schema
+  # type: [boolean, string]
+  # @schema
   # -- Enable use of per endpoint routes instead of routing via
   # the cilium_host interface.
   enabled: false
@@ -1019,6 +1112,9 @@ hubble:
   # See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics
   # for more comprehensive documentation about Hubble metrics.
   metrics:
+    # @schema
+    # type: [null, array]
+    # @schema
     # -- Configures the list of metrics to collect. If empty or null, metrics
     # are disabled.
     # Example:
@@ -1061,6 +1157,9 @@ hubble:
             - __meta_kubernetes_pod_node_name
           targetLabel: node
           replacement: ${1}
+      # @schema
+      # type: [null, array]
+      # @schema
       # -- Metrics relabeling configs for the ServiceMonitor hubble
       metricRelabelings: ~
     # -- Grafana dashboards for hubble
@@ -1069,6 +1168,9 @@ hubble:
     dashboards:
       enabled: false
       label: grafana_dashboard
+      # @schema
+      # type: [null, string]
+      # @schema
       namespace: ~
       labelValue: "1"
       annotations: {}
@@ -1157,6 +1259,9 @@ hubble:
   listenAddress: ":4244"
   # -- Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
   preferIpv6: false
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- (bool) Skip Hubble events with unknown cgroup ids
   # @default -- `true`
   skipUnknownCGroupIDs: ~
@@ -1286,9 +1391,15 @@ hubble:
       # -- enable PodDisruptionBudget
       # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
       enabled: false
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
       minAvailable: null
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
 
@@ -1302,6 +1413,9 @@ hubble:
     updateStrategy:
       type: RollingUpdate
       rollingUpdate:
+        # @schema
+        # type: [integer, string]
+        # @schema
         maxUnavailable: 1
 
     # -- Additional hubble-relay volumes.
@@ -1369,16 +1483,28 @@ hubble:
         # For GKE Dataplane V2 this should be set to relay.kube-system.svc.cluster.local
         relayName: "ui.hubble-relay.cilium.io"
 
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
     dialTimeout: ~
 
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
     retryTimeout: ~
 
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- Max number of flows that can be buffered for sorting before being sent to the
     # client (per request) (e.g. 100).
     sortBufferLenMax: ~
 
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- When the per-request flows sort buffer is not full, a flow is drained every
     # time this timeout is reached (only affects requests in follow-mode) (e.g. "1s").
     sortBufferDrainTimeout: ~
@@ -1406,8 +1532,14 @@ hubble:
         # -- Specify the Kubernetes namespace where Prometheus expects to find
         # service monitors configured.
         # namespace: ""
+        # @schema
+        # type: [null, array]
+        # @schema
         # -- Relabeling configs for the ServiceMonitor hubble-relay
         relabelings: ~
+        # @schema
+        # type: [null, array]
+        # @schema
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
         metricRelabelings: ~
 
@@ -1557,9 +1689,15 @@ hubble:
       # -- enable PodDisruptionBudget
       # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
       enabled: false
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
       minAvailable: null
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
 
@@ -1588,6 +1726,9 @@ hubble:
     updateStrategy:
       type: RollingUpdate
       rollingUpdate:
+        # @schema
+        # type: [integer, string]
+        # @schema
         maxUnavailable: 1
 
     # -- Security context to be added to Hubble UI pods
@@ -1694,10 +1835,16 @@ ipam:
   # -- Maximum rate at which the CiliumNode custom resource is updated.
   ciliumNodeUpdateRate: "15s"
   operator:
+    # @schema
+    # type: [array, string]
+    # @schema
     # -- IPv4 CIDR list range to delegate to individual nodes for IPAM.
     clusterPoolIPv4PodCIDRList: ["10.0.0.0/8"]
     # -- IPv4 CIDR mask size to delegate to individual nodes for IPAM.
     clusterPoolIPv4MaskSize: 24
+    # @schema
+    # type: [array, string]
+    # @schema
     # -- IPv6 CIDR list range to delegate to individual nodes for IPAM.
     clusterPoolIPv6PodCIDRList: ["fd00::/104"]
     # -- IPv6 CIDR mask size to delegate to individual nodes for IPAM.
@@ -1714,16 +1861,25 @@ ipam:
       #     cidrs:
       #       - fd00:100::/80
       #     maskSize: 96
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- The maximum burst size when rate limiting access to external APIs.
     # Also known as the token bucket capacity.
     # @default -- `20`
     externalAPILimitBurstSize: ~
+    # @schema
+    # type: [null, number]
+    # @schema
     # -- The maximum queries per second when rate limiting access to
     # external APIs. Also known as the bucket refill rate, which is used to
     # refill the bucket up to the burst size capacity.
     # @default -- `4.0`
     externalAPILimitQPS: ~
 
+# @schema
+# type: [null, string]
+# @schema
 # -- The api-rate-limit option can be used to overwrite individual settings of the default configuration for rate limiting calls to the Cilium Agent API
 apiRateLimit: ~
 
@@ -1970,6 +2126,9 @@ nodePort:
 # ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
 policyEnforcementMode: "default"
 
+# @schema
+# type: [null, string, array]
+# @schema
 # -- policyCIDRMatchMode is a list of entities that may be selected by CIDR selector.
 # The possible value is "nodes".
 policyCIDRMatchMode:
@@ -2007,11 +2166,17 @@ prometheus:
           - __meta_kubernetes_pod_node_name
         targetLabel: node
         replacement: ${1}
+    # @schema
+    # type: [null, array]
+    # @schema
     # -- Metrics relabeling configs for the ServiceMonitor cilium-agent
     metricRelabelings: ~
     # -- Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying
     trustCRDsExist: false
 
+  # @schema
+  # type: [null, array]
+  # @schema
   # -- Metrics that should be enabled or disabled from the default metric list.
   # The list is expected to be separated by a space. (+metric_foo to enable
   # metric_foo , -metric_bar to disable metric_bar).
@@ -2034,6 +2199,9 @@ prometheus:
 dashboards:
   enabled: false
   label: grafana_dashboard
+  # @schema
+  # type: [null, string]
+  # @schema
   namespace: ~
   labelValue: "1"
   annotations: {}
@@ -2044,6 +2212,9 @@ proxy:
   prometheus:
     # -- Deprecated in favor of envoy.prometheus.enabled
     enabled: true
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- Deprecated in favor of envoy.prometheus.port
     port: ~
   # -- Regular expression matching compatible Istio sidecar istio-proxy
@@ -2115,6 +2286,9 @@ envoy:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxUnavailable: 2
   # -- Roll out cilium envoy pods automatically when configmap is updated.
   rollOutPods: false
@@ -2207,9 +2381,15 @@ envoy:
     #   value: "value"
     #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- The priority class to use for cilium-envoy.
   priorityClassName: ~
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- DNS policy for Cilium envoy pods.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ~
@@ -2241,6 +2421,9 @@ envoy:
             - __meta_kubernetes_pod_node_name
           targetLabel: node
           replacement: ${1}
+      # @schema
+      # type: [null, array]
+      # @schema
       # -- Metrics relabeling configs for the ServiceMonitor cilium-envoy
       # or for cilium-agent with Envoy configured.
       metricRelabelings: ~
@@ -2427,9 +2610,15 @@ etcd:
     # -- enable PodDisruptionBudget
     # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
     enabled: false
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
     minAvailable: null
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Maximum number/percentage of pods that may be made unavailable
     maxUnavailable: 1
 
@@ -2451,7 +2640,13 @@ etcd:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxSurge: 1
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxUnavailable: 1
 
   # -- If etcd is behind a k8s service set this option to true so that Cilium
@@ -2508,7 +2703,13 @@ operator:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxSurge: 25%
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxUnavailable: 50%
 
   # -- Affinity for cilium-operator
@@ -2578,9 +2779,15 @@ operator:
     # -- enable PodDisruptionBudget
     # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
     enabled: true
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
     minAvailable: null
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Maximum number/percentage of pods that may be made unavailable
     maxUnavailable: 1
 
@@ -2638,8 +2845,14 @@ operator:
       jobLabel: ""
       # -- Interval for scrape metrics.
       interval: "10s"
+      # @schema
+      # type: [null, array]
+      # @schema
       # -- Relabeling configs for the ServiceMonitor cilium-operator
       relabelings: ~
+      # @schema
+      # type: [null, array]
+      # @schema
       # -- Metrics relabeling configs for the ServiceMonitor cilium-operator
       metricRelabelings: ~
 
@@ -2649,6 +2862,9 @@ operator:
   dashboards:
     enabled: false
     label: grafana_dashboard
+    # @schema
+    # type: [null, string]
+    # @schema
     namespace: ~
     labelValue: "1"
     annotations: {}
@@ -2660,6 +2876,9 @@ operator:
   # pod running.
   removeNodeTaints: true
 
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- Taint nodes where Cilium is scheduled but not running. This prevents pods
   # from being scheduled to nodes where Cilium is not the default CNI provider.
   # @default -- same as removeNodeTaints
@@ -2848,9 +3067,15 @@ preflight:
     # -- enable PodDisruptionBudget
     # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
     enabled: false
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
     minAvailable: null
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Maximum number/percentage of pods that may be made unavailable
     maxUnavailable: 1
 
@@ -3034,12 +3259,17 @@ clustermesh:
       # For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
       annotations: {}
 
+      # @schema
+      # enum: [Local, Cluster]
+      # @schema
       # -- The externalTrafficPolicy of service used for apiserver access.
-      externalTrafficPolicy:
+      externalTrafficPolicy: Cluster
 
+      # @schema
+      # enum: [Local, Cluster]
+      # @schema
       # -- The internalTrafficPolicy of service used for apiserver access.
-      internalTrafficPolicy:
-
+      internalTrafficPolicy: Cluster
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
 
@@ -3078,9 +3308,15 @@ clustermesh:
       # -- enable PodDisruptionBudget
       # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
       enabled: false
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
       minAvailable: null
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
 
@@ -3129,6 +3365,9 @@ clustermesh:
     updateStrategy:
       type: RollingUpdate
       rollingUpdate:
+        # @schema
+        # type: [integer, string]
+        # @schema
         maxUnavailable: 1
 
     # -- The priority class to use for clustermesh-apiserver
@@ -3251,24 +3490,42 @@ clustermesh:
 
         # -- Interval for scrape metrics (apiserver metrics)
         interval: "10s"
+        # @schema
+        # type: [null, array]
+        # @schema
         # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
         relabelings: ~
+        # @schema
+        # type: [null, array]
+        # @schema
         # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
         metricRelabelings: ~
 
         kvstoremesh:
           # -- Interval for scrape metrics (KVStoreMesh metrics)
           interval: "10s"
+          # @schema
+          # type: [null, array]
+          # @schema
           # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics)
           relabelings: ~
+          # @schema
+          # type: [null, array]
+          # @schema
           # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics)
           metricRelabelings: ~
 
         etcd:
           # -- Interval for scrape metrics (etcd metrics)
           interval: "10s"
+          # @schema
+          # type: [null, array]
+          # @schema
           # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
           relabelings: ~
+          # @schema
+          # type: [null, array]
+          # @schema
           # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
           metricRelabelings: ~
 
@@ -3474,6 +3731,9 @@ authentication:
             size: 1Gi
             # -- Access mode of the SPIRE server data storage
             accessMode: ReadWriteOnce
+            # @schema
+            # type: [null, string]
+            # @schema
             # -- StorageClass of the SPIRE server data storage
             storageClass: null
           # -- Security context to be added to spire server pods.
@@ -3494,6 +3754,9 @@ authentication:
               country: "US"
               organization: "SPIRE"
               commonName: "Cilium SPIRE CA"
+      # @schema
+      # type: [null, string]
+      # @schema
       # -- SPIRE server address used by Cilium Operator
       #
       # If k8s Service DNS along with port number is used (e.g. <service-name>.<namespace>.svc(.*):<port-number> format),

--- a/helm/cilium/values.yaml.tmpl
+++ b/helm/cilium/values.yaml.tmpl
@@ -8,6 +8,9 @@
 debug:
   # -- Enable debug logging
   enabled: false
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Configure verbosity levels for debug logging
   # This option is used to enable debug messages for operations related to such
   # sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is
@@ -27,7 +30,7 @@ rbac:
   create: true
 
 # -- Configure image pull secrets for pulling container images
-imagePullSecrets:
+imagePullSecrets: []
 # - name: "image-pull-secret"
 
 # -- (string) Kubernetes config path
@@ -35,6 +38,9 @@ imagePullSecrets:
 kubeConfigPath: ""
 # -- (string) Kubernetes service host
 k8sServiceHost: ""
+# @schema
+# type: [string, integer]
+# @schema
 # -- (string) Kubernetes service port
 k8sServicePort: ""
 
@@ -44,9 +50,15 @@ k8sServicePort: ""
 # rate limit, the agent and operator will start to throttle requests by delaying
 # them until there is budget or the request times out.
 k8sClientRateLimit:
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) The sustained request rate in requests per second.
   # @default -- 5 for k8s up to 1.26. 10 for k8s version 1.27+
   qps:
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) The burst request rate in requests per second.
   # The rate limiter will allow short bursts with a higher rate.
   # @default -- 10 for k8s up to 1.26. 20 for k8s version 1.27+
@@ -332,6 +344,9 @@ securityContext:
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
+    # @schema
+    # type: [integer, string]
+    # @schema
     maxUnavailable: 2
 
 # Configuration Values for cilium-agent
@@ -342,6 +357,9 @@ aksbyocni:
   # use Azure integration (`azure.enabled`) instead.
   enabled: false
 
+# @schema
+# type: [boolean, string]
+# @schema
 # -- Enable installation of PodCIDR routes between worker
 # nodes if worker nodes share a common L2 network segment.
 autoDirectNodeRoutes: false
@@ -449,35 +467,59 @@ bpf:
   # memory usage but can reduce latency.
   preallocateMaps: false
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries in auth map.
   # @default -- `524288`
   authMapMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries in the TCP connection tracking
   # table.
   # @default -- `524288`
   ctTcpMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries for the non-TCP connection
   # tracking table.
   # @default -- `262144`
   ctAnyMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Configure the maximum number of service entries in the
   # load balancer maps.
   lbMapMax: 65536
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries for the NAT table.
   # @default -- `524288`
   natMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- (int) Configure the maximum number of entries for the neighbor table.
   # @default -- `524288`
   neighMax: ~
 
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
   policyMapMax: 16384
 
+  # @schema
+  # type: [null, number]
+  # @schema
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
   # @default -- `0.0025`
@@ -498,10 +540,16 @@ bpf:
   # -- Allow cluster external access to ClusterIP services.
   lbExternalClusterIP: false
 
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- (bool) Enable native IP masquerade support in eBPF
   # @default -- `false`
   masquerade: ~
 
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- (bool) Configure whether direct routing mode should route traffic via
   # host stack (true) or directly and more efficiently out of BPF (false) if
   # the kernel supports it. The latter has the implication that it will also
@@ -509,11 +557,17 @@ bpf:
   # @default -- `false`
   hostLegacyRouting: ~
 
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- (bool) Configure the eBPF-based TPROXY to reduce reliance on iptables rules
   # for implementing Layer 7 policy.
   # @default -- `false`
   tproxy: ~
 
+  # @schema
+  # type: [null, array]
+  # @schema
   # -- (list) Configure explicitly allowed VLAN id's for bpf logic bypass.
   # [0] will allow all VLAN id's without any filtering.
   # @default -- `[]`
@@ -550,6 +604,9 @@ cni:
   # nodes to go unmanageable.
   uninstall: false
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Configure chaining on top of other CNI plugins. Possible values:
   #  - none
   #  - aws-cni
@@ -558,6 +615,9 @@ cni:
   #  - portmap
   chainingMode: ~
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- A CNI network name in to which the Cilium plugin should be added as a chained plugin.
   # This will cause the agent to watch for a CNI network with this network name. When it is
   # found, this will be used as the basis for Cilium's CNI configuration file. If this is
@@ -647,12 +707,18 @@ daemon:
   # -- Configure where Cilium runtime state should be stored.
   runPath: "/var/run/cilium"
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Configure a custom list of possible configuration override sources
   # The default is "config-map:cilium-config,cilium-node-config". For supported
   # values, see the help text for the build-config subcommand.
   # Note that this value should be a comma-separated string.
   configSources: ~
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- allowedConfigOverrides is a list of config-map keys that can be overridden.
   # That is to say, if this value is set, config sources (excepting the first one) can
   # only override keys in this list.
@@ -663,6 +729,9 @@ daemon:
   # change the configSources variable.
   allowedConfigOverrides: ~
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- blockedConfigOverrides is a list of config-map keys that may not be overridden.
   # In other words, if any of these keys appear in a configuration source excepting the
   # first one, they will be ignored
@@ -738,9 +807,15 @@ ingressController:
   # -- IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service
   ingressLBAnnotationPrefixes: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Default secret namespace for ingresses without .spec.tls[].secretName set.
   defaultSecretNamespace:
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- Default secret name for ingresses without .spec.tls[].secretName set.
   defaultSecretName:
 
@@ -767,14 +842,29 @@ ingressController:
     annotations: {}
     # -- Service type for the shared LB service
     type: LoadBalancer
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- Configure a specific nodePort for insecure HTTP traffic on the shared LB service
     insecureNodePort: ~
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- Configure a specific nodePort for secure HTTPS traffic on the shared LB service
     secureNodePort : ~
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+)
     loadBalancerClass: ~
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- Configure a specific loadBalancerIP on the shared LB service
     loadBalancerIP : ~
+    # @schema
+    # type: [null, boolean]
+    # @schema
     # -- Configure if node port allocation is required for LB service
     # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
     allocateLoadBalancerNodePorts: ~
@@ -883,6 +973,9 @@ endpointStatus:
   status: ""
 
 endpointRoutes:
+  # @schema
+  # type: [boolean, string]
+  # @schema
   # -- Enable use of per endpoint routes instead of routing via
   # the cilium_host interface.
   enabled: false
@@ -962,7 +1055,7 @@ socketLB:
   enabled: false
 
   # -- Disable socket lb for non-root ns. This is used to enable Istio routing rules.
-  # hostNamespaceOnly: false
+  hostNamespaceOnly: true
 
 # -- Configure certificate generation for Hubble integration.
 # If hubble.tls.auto.method=cronJob, these values are used
@@ -1016,6 +1109,9 @@ hubble:
   # See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics
   # for more comprehensive documentation about Hubble metrics.
   metrics:
+    # @schema
+    # type: [null, array]
+    # @schema
     # -- Configures the list of metrics to collect. If empty or null, metrics
     # are disabled.
     # Example:
@@ -1058,6 +1154,9 @@ hubble:
             - __meta_kubernetes_pod_node_name
           targetLabel: node
           replacement: ${1}
+      # @schema
+      # type: [null, array]
+      # @schema
       # -- Metrics relabeling configs for the ServiceMonitor hubble
       metricRelabelings: ~
     # -- Grafana dashboards for hubble
@@ -1066,6 +1165,9 @@ hubble:
     dashboards:
       enabled: false
       label: grafana_dashboard
+      # @schema
+      # type: [null, string]
+      # @schema
       namespace: ~
       labelValue: "1"
       annotations: {}
@@ -1154,6 +1256,9 @@ hubble:
   listenAddress: ":4244"
   # -- Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
   preferIpv6: false
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- (bool) Skip Hubble events with unknown cgroup ids
   # @default -- `true`
   skipUnknownCGroupIDs: ~
@@ -1272,7 +1377,8 @@ hubble:
     annotations: {}
 
     # -- Annotations to be added to hubble-relay pods
-    podAnnotations: {}
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
     # -- Labels to be added to hubble-relay pods
     podLabels: {}
@@ -1282,9 +1388,15 @@ hubble:
       # -- enable PodDisruptionBudget
       # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
       enabled: false
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
       minAvailable: null
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
 
@@ -1298,6 +1410,9 @@ hubble:
     updateStrategy:
       type: RollingUpdate
       rollingUpdate:
+        # @schema
+        # type: [integer, string]
+        # @schema
         maxUnavailable: 1
 
     # -- Additional hubble-relay volumes.
@@ -1365,16 +1480,28 @@ hubble:
         # For GKE Dataplane V2 this should be set to relay.kube-system.svc.cluster.local
         relayName: "ui.hubble-relay.cilium.io"
 
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
     dialTimeout: ~
 
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
     retryTimeout: ~
 
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- Max number of flows that can be buffered for sorting before being sent to the
     # client (per request) (e.g. 100).
     sortBufferLenMax: ~
 
+    # @schema
+    # type: [null, string]
+    # @schema
     # -- When the per-request flows sort buffer is not full, a flow is drained every
     # time this timeout is reached (only affects requests in follow-mode) (e.g. "1s").
     sortBufferDrainTimeout: ~
@@ -1402,8 +1529,14 @@ hubble:
         # -- Specify the Kubernetes namespace where Prometheus expects to find
         # service monitors configured.
         # namespace: ""
+        # @schema
+        # type: [null, array]
+        # @schema
         # -- Relabeling configs for the ServiceMonitor hubble-relay
         relabelings: ~
+        # @schema
+        # type: [null, array]
+        # @schema
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
         metricRelabelings: ~
 
@@ -1542,7 +1675,8 @@ hubble:
     annotations: {}
 
     # -- Annotations to be added to hubble-ui pods
-    podAnnotations: {}
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
     # -- Labels to be added to hubble-ui pods
     podLabels: {}
@@ -1552,9 +1686,15 @@ hubble:
       # -- enable PodDisruptionBudget
       # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
       enabled: false
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
       minAvailable: null
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
 
@@ -1583,6 +1723,9 @@ hubble:
     updateStrategy:
       type: RollingUpdate
       rollingUpdate:
+        # @schema
+        # type: [integer, string]
+        # @schema
         maxUnavailable: 1
 
     # -- Security context to be added to Hubble UI pods
@@ -1689,10 +1832,16 @@ ipam:
   # -- Maximum rate at which the CiliumNode custom resource is updated.
   ciliumNodeUpdateRate: "15s"
   operator:
+    # @schema
+    # type: [array, string]
+    # @schema
     # -- IPv4 CIDR list range to delegate to individual nodes for IPAM.
     clusterPoolIPv4PodCIDRList: ["10.0.0.0/8"]
     # -- IPv4 CIDR mask size to delegate to individual nodes for IPAM.
     clusterPoolIPv4MaskSize: 24
+    # @schema
+    # type: [array, string]
+    # @schema
     # -- IPv6 CIDR list range to delegate to individual nodes for IPAM.
     clusterPoolIPv6PodCIDRList: ["fd00::/104"]
     # -- IPv6 CIDR mask size to delegate to individual nodes for IPAM.
@@ -1709,16 +1858,25 @@ ipam:
       #     cidrs:
       #       - fd00:100::/80
       #     maskSize: 96
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- The maximum burst size when rate limiting access to external APIs.
     # Also known as the token bucket capacity.
     # @default -- `20`
     externalAPILimitBurstSize: ~
+    # @schema
+    # type: [null, number]
+    # @schema
     # -- The maximum queries per second when rate limiting access to
     # external APIs. Also known as the bucket refill rate, which is used to
     # refill the bucket up to the burst size capacity.
     # @default -- `4.0`
     externalAPILimitQPS: ~
 
+# @schema
+# type: [null, string]
+# @schema
 # -- The api-rate-limit option can be used to overwrite individual settings of the default configuration for rate limiting calls to the Cilium Agent API
 apiRateLimit: ~
 
@@ -1965,6 +2123,9 @@ nodePort:
 # ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
 policyEnforcementMode: "default"
 
+# @schema
+# type: [null, string, array]
+# @schema
 # -- policyCIDRMatchMode is a list of entities that may be selected by CIDR selector.
 # The possible value is "nodes".
 policyCIDRMatchMode:
@@ -2002,11 +2163,17 @@ prometheus:
           - __meta_kubernetes_pod_node_name
         targetLabel: node
         replacement: ${1}
+    # @schema
+    # type: [null, array]
+    # @schema
     # -- Metrics relabeling configs for the ServiceMonitor cilium-agent
     metricRelabelings: ~
     # -- Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying
     trustCRDsExist: false
 
+  # @schema
+  # type: [null, array]
+  # @schema
   # -- Metrics that should be enabled or disabled from the default metric list.
   # The list is expected to be separated by a space. (+metric_foo to enable
   # metric_foo , -metric_bar to disable metric_bar).
@@ -2029,6 +2196,9 @@ prometheus:
 dashboards:
   enabled: false
   label: grafana_dashboard
+  # @schema
+  # type: [null, string]
+  # @schema
   namespace: ~
   labelValue: "1"
   annotations: {}
@@ -2039,6 +2209,9 @@ proxy:
   prometheus:
     # -- Deprecated in favor of envoy.prometheus.enabled
     enabled: true
+    # @schema
+    # type: [null, integer]
+    # @schema
     # -- Deprecated in favor of envoy.prometheus.port
     port: ~
   # -- Regular expression matching compatible Istio sidecar istio-proxy
@@ -2110,6 +2283,9 @@ envoy:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxUnavailable: 2
   # -- Roll out cilium envoy pods automatically when configmap is updated.
   rollOutPods: false
@@ -2202,9 +2378,15 @@ envoy:
     #   value: "value"
     #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- The priority class to use for cilium-envoy.
   priorityClassName: ~
 
+  # @schema
+  # type: [null, string]
+  # @schema
   # -- DNS policy for Cilium envoy pods.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ~
@@ -2236,6 +2418,9 @@ envoy:
             - __meta_kubernetes_pod_node_name
           targetLabel: node
           replacement: ${1}
+      # @schema
+      # type: [null, array]
+      # @schema
       # -- Metrics relabeling configs for the ServiceMonitor cilium-envoy
       # or for cilium-agent with Envoy configured.
       metricRelabelings: ~
@@ -2422,9 +2607,15 @@ etcd:
     # -- enable PodDisruptionBudget
     # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
     enabled: false
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
     minAvailable: null
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Maximum number/percentage of pods that may be made unavailable
     maxUnavailable: 1
 
@@ -2446,7 +2637,13 @@ etcd:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxSurge: 1
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxUnavailable: 1
 
   # -- If etcd is behind a k8s service set this option to true so that Cilium
@@ -2503,7 +2700,13 @@ operator:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxSurge: 25%
+      # @schema
+      # type: [integer, string]
+      # @schema
       maxUnavailable: 50%
 
   # -- Affinity for cilium-operator
@@ -2573,9 +2776,15 @@ operator:
     # -- enable PodDisruptionBudget
     # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
     enabled: true
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
     minAvailable: null
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Maximum number/percentage of pods that may be made unavailable
     maxUnavailable: 1
 
@@ -2633,8 +2842,14 @@ operator:
       jobLabel: ""
       # -- Interval for scrape metrics.
       interval: "10s"
+      # @schema
+      # type: [null, array]
+      # @schema
       # -- Relabeling configs for the ServiceMonitor cilium-operator
       relabelings: ~
+      # @schema
+      # type: [null, array]
+      # @schema
       # -- Metrics relabeling configs for the ServiceMonitor cilium-operator
       metricRelabelings: ~
 
@@ -2644,6 +2859,9 @@ operator:
   dashboards:
     enabled: false
     label: grafana_dashboard
+    # @schema
+    # type: [null, string]
+    # @schema
     namespace: ~
     labelValue: "1"
     annotations: {}
@@ -2655,6 +2873,9 @@ operator:
   # pod running.
   removeNodeTaints: true
 
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- Taint nodes where Cilium is scheduled but not running. This prevents pods
   # from being scheduled to nodes where Cilium is not the default CNI provider.
   # @default -- same as removeNodeTaints
@@ -2843,9 +3064,15 @@ preflight:
     # -- enable PodDisruptionBudget
     # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
     enabled: false
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
     minAvailable: null
+    # @schema
+    # type: [null, integer, string]
+    # @schema
     # -- Maximum number/percentage of pods that may be made unavailable
     maxUnavailable: 1
 
@@ -3029,12 +3256,17 @@ clustermesh:
       # For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
       annotations: {}
 
+      # @schema
+      # enum: [Local, Cluster]
+      # @schema
       # -- The externalTrafficPolicy of service used for apiserver access.
-      externalTrafficPolicy:
+      externalTrafficPolicy: Cluster
 
+      # @schema
+      # enum: [Local, Cluster]
+      # @schema
       # -- The internalTrafficPolicy of service used for apiserver access.
-      internalTrafficPolicy:
-
+      internalTrafficPolicy: Cluster
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
 
@@ -3073,9 +3305,15 @@ clustermesh:
       # -- enable PodDisruptionBudget
       # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
       enabled: false
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
       minAvailable: null
+      # @schema
+      # type: [null, integer, string]
+      # @schema
       # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
 
@@ -3124,6 +3362,9 @@ clustermesh:
     updateStrategy:
       type: RollingUpdate
       rollingUpdate:
+        # @schema
+        # type: [integer, string]
+        # @schema
         maxUnavailable: 1
 
     # -- The priority class to use for clustermesh-apiserver
@@ -3246,24 +3487,42 @@ clustermesh:
 
         # -- Interval for scrape metrics (apiserver metrics)
         interval: "10s"
+        # @schema
+        # type: [null, array]
+        # @schema
         # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
         relabelings: ~
+        # @schema
+        # type: [null, array]
+        # @schema
         # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
         metricRelabelings: ~
 
         kvstoremesh:
           # -- Interval for scrape metrics (KVStoreMesh metrics)
           interval: "10s"
+          # @schema
+          # type: [null, array]
+          # @schema
           # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics)
           relabelings: ~
+          # @schema
+          # type: [null, array]
+          # @schema
           # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics)
           metricRelabelings: ~
 
         etcd:
           # -- Interval for scrape metrics (etcd metrics)
           interval: "10s"
+          # @schema
+          # type: [null, array]
+          # @schema
           # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
           relabelings: ~
+          # @schema
+          # type: [null, array]
+          # @schema
           # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
           metricRelabelings: ~
 
@@ -3469,6 +3728,9 @@ authentication:
             size: 1Gi
             # -- Access mode of the SPIRE server data storage
             accessMode: ReadWriteOnce
+            # @schema
+            # type: [null, string]
+            # @schema
             # -- StorageClass of the SPIRE server data storage
             storageClass: null
           # -- Security context to be added to spire server pods.
@@ -3489,6 +3751,9 @@ authentication:
               country: "US"
               organization: "SPIRE"
               commonName: "Cilium SPIRE CA"
+      # @schema
+      # type: [null, string]
+      # @schema
       # -- SPIRE server address used by Cilium Operator
       #
       # If k8s Service DNS along with port number is used (e.g. <service-name>.<namespace>.svc(.*):<port-number> format),

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Add safe-to-evict annotations to Hubble Relay and UI (#18)...
-      sha: fd765921724555b37e0cfbc11ee97791413aa2ff
+      commitTitle: Backport helm schema from upstream (#20)
+      sha: 3e632da7ab56811ce7a430a86ca4274f385e9fd9
       tags:
-      - 1.15.1-41-gfd76592172
+      - 1.15.1-42-g3e632da7ab
     path: cilium
   path: vendor
 - contents:


### PR DESCRIPTION
<!--
This app is generated from the contents on [our cilium fork](https://github.com/giantswarm/cilium-upstream).
Manual changes to this repo will be lost the next time the app is generated from the fork.
If you need to change something, please do it on the fork, and then re-generate the app.
-->

This PR:

- adds a helm values schema file

Tested this on capa, capz, capv and capvcd using the cluster test suites available in their respective repositories:

- capa Works (test failed because of some other error)
- capz Works
- capv Works
- capvcd Works (test failed because of some other error)

https://github.com/giantswarm/giantswarm/issues/29542

### Checklist

- [x] Update changelog in CHANGELOG.md.
