### PR TITLE
Enable deletion of extra network policies in job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Add safe-to-evict annotations to Hubble Relay and UI pods.
-
 ### Added
 
 - Add helm values schema.
+
+### Changed
+
+- Add safe-to-evict annotations to Hubble Relay and UI pods.
+- Enable deletion of extra network policies.
 
 ## [0.21.0] - 2024-02-29
 

--- a/helm/cilium/templates/extra-policies/configmap.yaml
+++ b/helm/cilium/templates/extra-policies/configmap.yaml
@@ -1,4 +1,10 @@
-{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled -}}
+{{- if and .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.remove -}}
+{{- fail "extraPolicies.allowEgressToCoreDNS.enabled and extraPolicies.remove cannot both be true" -}}
+{{- end -}}
+{{- if and .Values.extraPolicies.allowEgressToProxy.enabled .Values.extraPolicies.remove -}}
+{{- fail "extraPolicies.allowEgressToProxy.enabled and extraPolicies.remove cannot both be true" -}}
+{{- end -}}
+{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled .Values.extraPolicies.remove -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/cilium/templates/extra-policies/job.yaml
+++ b/helm/cilium/templates/extra-policies/job.yaml
@@ -1,11 +1,11 @@
-{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled -}}
+{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled .Values.extraPolicies.remove -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cilium-create-extra-policies
+  name: cilium-{{ ternary "remove" "create" .Values.extraPolicies.remove }}-extra-policies
   namespace: {{ .Release.Namespace }}
   labels:
-    app: cilium-create-extra-policies
+    app: cilium-{{ ternary "remove" "create" .Values.extraPolicies.remove }}-extra-policies
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "1"
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: cilium-create-extra-policies
+        app: cilium-{{ ternary "remove" "create" .Values.extraPolicies.remove }}-extra-policies
     spec:
       hostNetwork: true
       restartPolicy: OnFailure
@@ -47,7 +47,7 @@ spec:
             done
           done
       containers:
-      - name: cilium-create-extra-policies
+      - name: cilium-{{ ternary "remove" "create" .Values.extraPolicies.remove }}-extra-policies
         image: "{{ .Values.image.registry }}/giantswarm/docker-kubectl:latest"
         imagePullPolicy: IfNotPresent
         volumeMounts:
@@ -60,5 +60,13 @@ spec:
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
 
-          kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /policies/ 2>&1
+          kubectl \
+{{- if .Values.extraPolicies.remove }}
+            delete \
+            --ignore-not-found \
+{{- else }}
+            apply \
+            --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts \
+{{- end }}
+            -f /policies/ 2>&1
 {{- end -}}

--- a/helm/cilium/templates/extra-policies/job.yaml
+++ b/helm/cilium/templates/extra-policies/job.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled .Values.extraPolicies.remove -}}
+{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled .Values.extraPolicies.remove }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -60,13 +60,17 @@ spec:
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
 
+          {{- if .Values.extraPolicies.remove }}
+          {{- range $_, $ns := $.Values.extraPolicies.allowEgressToCoreDNS.namespaces }}
+          {{ printf "kubectl delete cnp -n %s %s --ignore-not-found 2>&1" $ns "cilium-extra-policies-dns" }}
+          {{- end }}
+          {{- range $_, $ns := $.Values.extraPolicies.allowEgressToProxy.namespaces }}
+          {{ printf "kubectl delete cnp -n %s %s --ignore-not-found 2>&1" $ns "cilium-extra-policies-proxy" }}
+          {{- end }}
+          {{- else }}
           kubectl \
-{{- if .Values.extraPolicies.remove }}
-            delete \
-            --ignore-not-found \
-{{- else }}
             apply \
             --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts \
-{{- end }}
             -f /policies/ 2>&1
-{{- end -}}
+          {{- end }}
+{{- end }}

--- a/helm/cilium/templates/extra-policies/podsecuritypolicy.yaml
+++ b/helm/cilium/templates/extra-policies/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled) (not .Values.global.podSecurityStandards.enforced) -}}
+{{- if and (or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled .Values.extraPolicies.remove) (not .Values.global.podSecurityStandards.enforced) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/cilium/templates/extra-policies/rbac.yaml
+++ b/helm/cilium/templates/extra-policies/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled -}}
+{{- if or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled .Values.extraPolicies.remove -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -12,6 +12,7 @@ rules:
   verbs:
   - patch
   - create
+  - delete
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/helm/cilium/templates/extra-policies/serviceaccount.yaml
+++ b/helm/cilium/templates/extra-policies/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled) .Values.serviceAccounts.extraPolicies.create -}}
+{{- if and (or .Values.extraPolicies.allowEgressToCoreDNS.enabled .Values.extraPolicies.allowEgressToProxy.enabled .Values.extraPolicies.remove) .Values.serviceAccounts.extraPolicies.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/cilium/values.schema.json
+++ b/helm/cilium/values.schema.json
@@ -2090,6 +2090,9 @@
     },
     "extraPolicies": {
       "properties": {
+        "remove": {
+          "type": "boolean"
+        },
         "allowEgressToCoreDNS": {
           "properties": {
             "enabled": {

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -3784,6 +3784,8 @@ defaultPolicies:
   - operator: Exists
 
 extraPolicies:
+  remove: false
+
   allowEgressToCoreDNS:
     enabled: false
     namespaces:

--- a/helm/cilium/values.yaml.tmpl
+++ b/helm/cilium/values.yaml.tmpl
@@ -3781,6 +3781,8 @@ defaultPolicies:
   - operator: Exists
 
 extraPolicies:
+  remove: false
+
   allowEgressToCoreDNS:
     enabled: false
     namespaces:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: 'Chart Makefile: Only specify --userns=keep-id for podman (#21)...'
-      sha: 5bc3c59f0fe4c060e6abf94dc03dedc73d82e559
+      commitTitle: add some extra checks for extra policies deletion (#23)...
+      sha: d03ff1c98125211dbd4b243982ddde35192e9309
       tags:
-      - 1.15.1-44-g5bc3c59f0f
+      - 1.15.1-45-gd03ff1c981
     path: cilium
   path: vendor
 - contents:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Backport helm schema from upstream (#20)
-      sha: 3e632da7ab56811ce7a430a86ca4274f385e9fd9
+      commitTitle: 'Chart Makefile: Only specify --userns=keep-id for podman (#21)...'
+      sha: 5bc3c59f0fe4c060e6abf94dc03dedc73d82e559
       tags:
-      - 1.15.1-42-g3e632da7ab
+      - 1.15.1-44-g5bc3c59f0f
     path: cilium
   path: vendor
 - contents:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
This app is generated from the contents on [our cilium fork](https://github.com/giantswarm/cilium-upstream).
Manual changes to this repo will be lost the next time the app is generated from the fork.
If you need to change something, please do it on the fork, and then re-generate the app.
-->

This PR:

- Enables the deletion of the extra-policies resources created by a job.

The idea is that setting `extraPolicies.remove` as `true` and `extraPolicies.allowEgressTo*.enabled` as `false`; the job deletes the previously created network policies. This has to be used in combination with the network-policies-app to ensure no disruption.

Towards https://github.com/giantswarm/roadmap/issues/3261

### Checklist

- [x] Update changelog in CHANGELOG.md.
