### PR TITLE
Cilium ENI mode for CAPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Cilium ENI mode for CAPA becomes usable with these changes
+
+  - Add security group tag filter for pod network
+  - Select subnets from secondary VPC CIDRs
+
 ## [0.22.0] - 2024-03-27
 
 ### Added

--- a/helm/cilium/templates/cilium-cni-configmap.yaml
+++ b/helm/cilium/templates/cilium-cni-configmap.yaml
@@ -48,15 +48,15 @@ data:
               {{- if and (not .Values.eksMode) (eq .Values.provider "capa") -}}
               {{/*
                   For CAPA EC2-based clusters (https://github.com/giantswarm/cluster-aws)
-
-                  The full ENI mode feature is in development (https://github.com/giantswarm/roadmap/issues/2563). Open TODOs:
-
-                  - Once a secondary VPC CIDR is added, this must be set as well for the below subnet tags selector: `"sigs.k8s.io/cluster-api-provider-aws/association": "secondary",`
-                  - And `"security-group-tags": [...]` should be added once there's a specific pod security group.
               */}}
               "first-interface-index": 1,
+              "security-group-tags": {
+                "kubernetes.io/cluster/{{ .Values.cluster.name }}": "owned",
+                "sigs.k8s.io/cluster-api-provider-aws/association": "secondary"
+              },
               "subnet-tags": {
                 "sigs.k8s.io/cluster-api-provider-aws/cluster/{{ .Values.cluster.name }}": "owned",
+                "sigs.k8s.io/cluster-api-provider-aws/association": "secondary",
                 "sigs.k8s.io/cluster-api-provider-aws/role": "private"
               }
               {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2563

For the full feature, I'm adding the correct security group and subnet selection, as we have in Vintage AWS.

### Checklist

- [x] Update changelog in CHANGELOG.md.
