### PR TITLE
Add app repo URL to sources in Chart.yaml

### DIFF
--- a/helm/cilium/Chart.yaml
+++ b/helm/cilium/Chart.yaml
@@ -16,6 +16,7 @@ keywords:
   - Observability
   - Troubleshooting
 sources:
+  - https://github.com/giantswarm/cilium-app
   - https://github.com/cilium/cilium
 links:
   - name: eBPF.io


### PR DESCRIPTION
This PR:

- adds this repo's URL to the Chart metadata. We need this in Backstage context to understand which GitHub repo this app originates from.

Context: https://github.com/giantswarm/roadmap/issues/3291

### Checklist

- [ ] Update changelog in CHANGELOG.md.
