### PR TITLE
Update chart to upstream v1.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade cilium to [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5).
+- Upgrade cilium to [v1.15.6](https://github.com/cilium/cilium/releases/tag/v1.15.6).
 
 ## [0.24.0] - 2024-04-30
 

--- a/helm/cilium/Chart.yaml
+++ b/helm/cilium/Chart.yaml
@@ -3,7 +3,7 @@ name: cilium
 displayName: Cilium
 home: https://cilium.io/
 version: 0.24.0
-appVersion: 1.15.5
+appVersion: 1.15.6
 kubeVersion: ">= 1.16.0-0"
 icon: https://cdn.jsdelivr.net/gh/cilium/cilium@v1.15/Documentation/images/logo-solo.svg
 description: eBPF-based Networking, Security, and Observability

--- a/helm/cilium/README.md
+++ b/helm/cilium/README.md
@@ -1,6 +1,6 @@
 # cilium
 
-![Version: 1.15.5](https://img.shields.io/badge/Version-1.15.5-informational?style=flat-square) ![AppVersion: 1.15.5](https://img.shields.io/badge/AppVersion-1.15.5-informational?style=flat-square)
+![Version: 1.15.6](https://img.shields.io/badge/Version-1.15.6-informational?style=flat-square) ![AppVersion: 1.15.6](https://img.shields.io/badge/AppVersion-1.15.6-informational?style=flat-square)
 
 Cilium is open source software for providing and transparently securing
 network connectivity and loadbalancing between application workloads such as
@@ -41,6 +41,7 @@ offer from the [Getting Started Guides page](https://docs.cilium.io/en/stable/ge
 
 ## Source Code
 
+* <https://github.com/giantswarm/cilium-app>
 * <https://github.com/cilium/cilium>
 
 ## Getting Help
@@ -172,7 +173,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
 | clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
-| clustermesh.apiserver.image | object | `{"digest":"sha256:914549caf4376a844b5e7696019182dd2a655b89d6a3cad10f9d0f9821759fd7","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-clustermesh-apiserver","tag":"v1.15.5","useDigest":true}` | Clustermesh API server image. |
+| clustermesh.apiserver.image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-clustermesh-apiserver","tag":"v1.15.6","useDigest":false}` | Clustermesh API server image. |
 | clustermesh.apiserver.kvstoremesh.enabled | bool | `false` | Enable KVStoreMesh. KVStoreMesh caches the information retrieved from the remote clusters in the local etcd instance. |
 | clustermesh.apiserver.kvstoremesh.extraArgs | list | `[]` | Additional KVStoreMesh arguments. |
 | clustermesh.apiserver.kvstoremesh.extraEnv | list | `[]` | Additional KVStoreMesh environment variables. |
@@ -339,7 +340,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:bc8dcc3bc008e3a5aab98edb73a0985e6ef9469bda49d5bb3004c001c995c380","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-envoy","tag":"v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:b528b291561e459024f66414ac3325b88cdd8f9f4854828a155a11e5b10b78a3","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-envoy","tag":"v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |
@@ -478,7 +479,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.extraVolumes | list | `[]` | Additional hubble-relay volumes. |
 | hubble.relay.gops.enabled | bool | `true` | Enable gops for hubble-relay |
 | hubble.relay.gops.port | int | `9893` | Configure gops listen port for hubble-relay |
-| hubble.relay.image | object | `{"digest":"sha256:1d24b24e3477ccf9b5ad081827db635419c136a2bd84a3e60f37b26a38dd0781","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/hubble-relay","tag":"v1.15.5","useDigest":true}` | Hubble-relay container image. |
+| hubble.relay.image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/hubble-relay","tag":"v1.15.6","useDigest":false}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
@@ -573,7 +574,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
 | identityAllocationMode | string | `"crd"` | Method to use for identity allocation (`crd` or `kvstore`). |
 | identityChangeGracePeriod | string | `"5s"` | Time to wait before using new identity on endpoint identity change. |
-| image | object | `{"digest":"sha256:4ce1666a73815101ec9a4d360af6c5b7f1193ab00d89b7124f8505dee147ca40","override":"","pullPolicy":"IfNotPresent","registry":"gsoci.azurecr.io","repository":"giantswarm/cilium","tag":"v1.15.5","useDigest":true}` | Agent container image. |
+| image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","registry":"gsoci.azurecr.io","repository":"giantswarm/cilium","tag":"v1.15.6","useDigest":false}` | Agent container image. |
 | imagePullSecrets | list | `[]` | Configure image pull secrets for pulling container images |
 | ingressController.default | bool | `false` | Set cilium ingress controller to be the default ingress controller This will let cilium ingress controller route entries without ingress class set |
 | ingressController.defaultSecretName | string | `nil` | Default secret name for ingresses without .spec.tls[].secretName set. |
@@ -689,7 +690,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.extraVolumes | list | `[]` | Additional cilium-operator volumes. |
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
-| operator.image | object | `{"alibabacloudDigest":"sha256:d76d45e308f23398b786f1f05504863759849046c20c741ebb64ad80613f8fd3","awsDigest":"sha256:f9c0eaea023ce5a75b3ed1fc4b783f390c5a3c7dc1507a2dc4dbc667b80d1bd9","azureDigest":"sha256:0a56f2cfdcdf13da21b7fdcc870e29fef82e71e599cd8dd74eb65c377e035522","genericDigest":"sha256:f5d3d19754074ca052be6aac5d1ffb1de1eb5f2d947222b5f10f6d97ad4383e8","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-operator","suffix":"","tag":"v1.15.5","useDigest":true}` | cilium-operator image. |
+| operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-operator","suffix":"","tag":"v1.15.6","useDigest":false}` | cilium-operator image. |
 | operator.nodeGCInterval | string | `"5m0s"` | Interval for cilium node garbage collection. |
 | operator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
@@ -740,7 +741,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |
 | preflight.extraVolumeMounts | list | `[]` | Additional preflight volumeMounts. |
 | preflight.extraVolumes | list | `[]` | Additional preflight volumes. |
-| preflight.image | object | `{"digest":"sha256:4ce1666a73815101ec9a4d360af6c5b7f1193ab00d89b7124f8505dee147ca40","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium","tag":"v1.15.5","useDigest":true}` | Cilium pre-flight image. |
+| preflight.image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium","tag":"v1.15.6","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
 | preflight.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |

--- a/helm/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/helm/cilium/templates/cilium-preflight/daemonset.yaml
@@ -180,6 +180,10 @@ spec:
       serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
       automountServiceAccountToken: {{ .Values.serviceAccounts.preflight.automount }}
       terminationGracePeriodSeconds: {{ .Values.preflight.terminationGracePeriodSeconds }}
+      {{- with .Values.preflight.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.preflight.tolerations }}
       tolerations:
         {{- toYaml . | trim | nindent 8 }}

--- a/helm/cilium/templates/hubble-ui/deployment.yaml
+++ b/helm/cilium/templates/hubble-ui/deployment.yaml
@@ -40,10 +40,8 @@ spec:
         {{- end }}
     spec:
       {{- with .Values.hubble.ui.securityContext }}
-        {{- if .enabled }}
       securityContext:
         {{- omit . "enabled" | toYaml | nindent 8 }}
-        {{- end}}
       {{- end }}
       priorityClassName: {{ .Values.hubble.ui.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.ui.name | quote }}

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -168,11 +168,11 @@ image:
   registry: gsoci.azurecr.io
   override: ""
   repository: "giantswarm/cilium"
-  tag: "v1.15.5"
+  tag: "v1.15.6"
   pullPolicy: "IfNotPresent"
   # cilium-digest
-  digest: "sha256:4ce1666a73815101ec9a4d360af6c5b7f1193ab00d89b7124f8505dee147ca40"
-  useDigest: true
+  digest: ""
+  useDigest: false
 
 # -- Affinity for cilium-agent.
 affinity:
@@ -1346,10 +1346,10 @@ hubble:
     image:
       override: ""
       repository: "giantswarm/hubble-relay"
-      tag: "v1.15.5"
+      tag: "v1.15.6"
        # hubble-relay-digest
-      digest: "sha256:1d24b24e3477ccf9b5ad081827db635419c136a2bd84a3e60f37b26a38dd0781"
-      useDigest: true
+      digest: ""
+      useDigest: false
       pullPolicy: "IfNotPresent"
 
     # -- Specifies the resources for the hubble-relay pods
@@ -2259,9 +2259,9 @@ envoy:
   image:
     override: ""
     repository: "giantswarm/cilium-envoy"
-    tag: "v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515"
+    tag: "v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:bc8dcc3bc008e3a5aab98edb73a0985e6ef9469bda49d5bb3004c001c995c380"
+    digest: "sha256:b528b291561e459024f66414ac3325b88cdd8f9f4854828a155a11e5b10b78a3"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.
@@ -2704,16 +2704,16 @@ operator:
   image:
     override: ""
     repository: "giantswarm/cilium-operator"
-    tag: "v1.15.5"
+    tag: "v1.15.6"
     # operator-generic-digest
-    genericDigest: "sha256:f5d3d19754074ca052be6aac5d1ffb1de1eb5f2d947222b5f10f6d97ad4383e8"
+    genericDigest: ""
     # operator-azure-digest
-    azureDigest: "sha256:0a56f2cfdcdf13da21b7fdcc870e29fef82e71e599cd8dd74eb65c377e035522"
+    azureDigest: ""
     # operator-aws-digest
-    awsDigest: "sha256:f9c0eaea023ce5a75b3ed1fc4b783f390c5a3c7dc1507a2dc4dbc667b80d1bd9"
+    awsDigest: ""
     # operator-alibabacloud-digest
-    alibabacloudDigest: "sha256:d76d45e308f23398b786f1f05504863759849046c20c741ebb64ad80613f8fd3"
-    useDigest: true
+    alibabacloudDigest: ""
+    useDigest: false
     pullPolicy: "IfNotPresent"
     suffix: ""
 
@@ -3029,10 +3029,10 @@ preflight:
   image:
     override: ""
     repository: "giantswarm/cilium"
-    tag: "v1.15.5"
+    tag: "v1.15.6"
     # cilium-digest
-    digest: "sha256:4ce1666a73815101ec9a4d360af6c5b7f1193ab00d89b7124f8505dee147ca40"
-    useDigest: true
+    digest: ""
+    useDigest: false
     pullPolicy: "IfNotPresent"
 
   # -- The priority class to use for the preflight pod.
@@ -3197,10 +3197,10 @@ clustermesh:
     image:
       override: ""
       repository: "giantswarm/cilium-clustermesh-apiserver"
-      tag: "v1.15.5"
+      tag: "v1.15.6"
       # clustermesh-apiserver-digest
-      digest: "sha256:914549caf4376a844b5e7696019182dd2a655b89d6a3cad10f9d0f9821759fd7"
-      useDigest: true
+      digest: ""
+      useDigest: false
       pullPolicy: "IfNotPresent"
 
     etcd:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Bump v1.15.5 (#26)...
-      sha: d591b7bad1a15539c35d3b1fac9d298828f8d7af
+      commitTitle: Update v1.15.6 (#27)...
+      sha: 97669716b354c655a21752f91c6b812666204f31
       tags:
-      - 1.15.1-50-gd591b7bad1
+      - 1.15.1-52-g97669716b3
     path: cilium
   path: vendor
 - contents:


### PR DESCRIPTION
<!--
This app is generated from the contents on [our cilium fork](https://github.com/giantswarm/cilium-upstream).
Manual changes to this repo will be lost the next time the app is generated from the fork.
If you need to change something, please do it on the fork, and then re-generate the app.
-->

This PR:

- Updates to upstream [v1.15.6](https://github.com/cilium/cilium/releases/tag/v1.15.6)

Tested to be working in:

- [CAPZ](https://github.com/giantswarm/cluster-azure/pull/291#issuecomment-2165593833)
- [CAPV](https://github.com/giantswarm/cluster-vsphere/pull/219#issuecomment-2165559935)
- [CAPA](https://github.com/giantswarm/cluster-aws/pull/656#issuecomment-2175753925)
- [CAPVCD](https://github.com/giantswarm/cluster-cloud-director/pull/321#issuecomment-2176032646)

### Checklist

- [x] Update changelog in CHANGELOG.md.
