### PR TITLE
Fix policyMapMax regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix regression setting Policy BPF Max map `policyMapMax` back to 65536 from 16384.
+
 ## [0.25.0] - 2024-06-19
 
 ### Changed

--- a/helm/cilium/README.md
+++ b/helm/cilium/README.md
@@ -138,7 +138,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.natMax | int | `524288` | Configure the maximum number of entries for the NAT table. |
 | bpf.neighMax | int | `524288` | Configure the maximum number of entries for the neighbor table. |
 | bpf.nodeMapMax | int | `nil` | Configures the maximum number of entries for the node table. |
-| bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). @schema type: [null, integer] @schema |
+| bpf.policyMapMax | int | `65536` | Configure the maximum number of entries in endpoint policy map (per endpoint). @schema type: [null, integer] @schema |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |
 | bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY to reduce reliance on iptables rules for implementing Layer 7 policy. |

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -527,7 +527,7 @@ bpf:
   # @schema
   # type: [null, integer]
   # @schema
-  policyMapMax: 16384
+  policyMapMax: 65536
 
   # @schema
   # type: [null, number]

--- a/helm/cilium/values.yaml.tmpl
+++ b/helm/cilium/values.yaml.tmpl
@@ -524,7 +524,7 @@ bpf:
   # @schema
   # type: [null, integer]
   # @schema
-  policyMapMax: 16384
+  policyMapMax: 65536
 
   # @schema
   # type: [null, number]

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Update v1.15.6 (#27)...
-      sha: 97669716b354c655a21752f91c6b812666204f31
+      commitTitle: revert policyMapMax regression
+      sha: be852bd3578d19298691a9bc7d848486daf423b7
       tags:
-      - 1.15.1-52-g97669716b3
+      - 1.15.1-53-gbe852bd357
     path: cilium
   path: vendor
 - contents:


### PR DESCRIPTION
<!--
This app is generated from the contents on [our cilium fork](https://github.com/giantswarm/cilium-upstream).
Manual changes to this repo will be lost the next time the app is generated from the fork.
If you need to change something, please do it on the fork, and then re-generate the app.
-->

This PR restores the changed `policyMapMax` value back to `65536` instead of upstream default `16384`. This was first changed in https://github.com/giantswarm/cilium-app/pull/80 and changed back to upstream default in https://github.com/giantswarm/cilium-app/pull/146/

### Checklist

- [x] Update changelog in CHANGELOG.md.
