### PR TITLE
 Re-enable agent metrics port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reenable Cilium agent metrics.
+
 ## [0.31.4] - 2025-05-20
 
 ### Changed

--- a/diffs/helm__cilium__templates__cilium-agent__service.yaml.patch
+++ b/diffs/helm__cilium__templates__cilium-agent__service.yaml.patch
@@ -1,0 +1,15 @@
+diff --git a/vendor/cilium/install/kubernetes/cilium/templates/cilium-agent/service.yaml b/helm/cilium/templates/cilium-agent/service.yaml
+index df97f5c..ea0def7 100644
+--- a/vendor/cilium/install/kubernetes/cilium/templates/cilium-agent/service.yaml
++++ b/helm/cilium/templates/cilium-agent/service.yaml
+@@ -49,6 +49,10 @@ spec:
+   selector:
+     k8s-app: cilium
+   ports:
++  - name: metrics
++    port: {{ .Values.prometheus.port }}
++    protocol: TCP
++    targetPort: prometheus
+   - name: envoy-metrics
+     port: {{ .Values.envoy.prometheus.port }}
+     protocol: TCP

--- a/helm/cilium/templates/cilium-agent/service.yaml
+++ b/helm/cilium/templates/cilium-agent/service.yaml
@@ -49,6 +49,10 @@ spec:
   selector:
     k8s-app: cilium
   ports:
+  - name: metrics
+    port: {{ .Values.prometheus.port }}
+    protocol: TCP
+    targetPort: prometheus
   - name: envoy-metrics
     port: {{ .Values.envoy.prometheus.port }}
     protocol: TCP

--- a/sync/patches/metrics_port/README.md
+++ b/sync/patches/metrics_port/README.md
@@ -1,0 +1,24 @@
+## How were patches generated?
+
+First, stage the changes (in `./helm`) and the run:
+
+> [!TIP]
+> Skip the `-R` flags if the changes were added.
+
+```bash
+git --no-pager diff -R helm/cilium/templates/cilium-agent/service.yaml \
+        > sync/patches/metrics_port/cilium_agent__service.yaml.patch
+```
+
+## What is the patched change?
+
+In case something goes wrong this is the raw change:
+
+In file `./helm/cilium/templates/cilium-agent/service.yaml` this port:
+
+```
+  - name: metrics
+    port: {{ .Values.prometheus.port }}
+    protocol: TCP
+    targetPort: prometheus
+```

--- a/sync/patches/metrics_port/cilium_agent__service.yaml.patch
+++ b/sync/patches/metrics_port/cilium_agent__service.yaml.patch
@@ -1,8 +1,8 @@
-diff --git b/helm/cilium/cilium/templates/cilium-agent/service.yaml a/helm/cilium/cilium/templates/cilium-agent/service.yaml
-index f6ec495..8a34bde 100644
---- b/helm/cilium/templates/cilium-agent/service.yaml
-+++ a/helm/cilium/templates/cilium-agent/service.yaml
-@@ -48,6 +48,10 @@ spec:
+diff --git a/helm/cilium/templates/cilium-agent/service.yaml b/helm/cilium/templates/cilium-agent/service.yaml
+index df97f5c..ea0def7 100644
+--- a/helm/cilium/templates/cilium-agent/service.yaml
++++ b/helm/cilium/templates/cilium-agent/service.yaml
+@@ -49,6 +49,10 @@ spec:
    selector:
      k8s-app: cilium
    ports:
@@ -11,5 +11,5 @@ index f6ec495..8a34bde 100644
 +    protocol: TCP
 +    targetPort: prometheus
    - name: envoy-metrics
-     port: {{ .Values.proxy.prometheus.port | default .Values.envoy.prometheus.port }}
+     port: {{ .Values.envoy.prometheus.port }}
      protocol: TCP

--- a/sync/patches/metrics_port/cilium_agent__service.yaml.patch
+++ b/sync/patches/metrics_port/cilium_agent__service.yaml.patch
@@ -1,0 +1,15 @@
+diff --git b/helm/cilium/cilium/templates/cilium-agent/service.yaml a/helm/cilium/cilium/templates/cilium-agent/service.yaml
+index f6ec495..8a34bde 100644
+--- b/helm/cilium/templates/cilium-agent/service.yaml
++++ a/helm/cilium/templates/cilium-agent/service.yaml
+@@ -48,6 +48,10 @@ spec:
+   selector:
+     k8s-app: cilium
+   ports:
++  - name: metrics
++    port: {{ .Values.prometheus.port }}
++    protocol: TCP
++    targetPort: prometheus
+   - name: envoy-metrics
+     port: {{ .Values.proxy.prometheus.port | default .Values.envoy.prometheus.port }}
+     protocol: TCP

--- a/sync/patches/metrics_port/patch.sh
+++ b/sync/patches/metrics_port/patch.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_dir=$(git rev-parse --show-toplevel) ; readonly repo_dir
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ; readonly script_dir
+
+cd "${repo_dir}"
+
+readonly script_dir_rel=".${script_dir#"${repo_dir}"}"
+
+set -x
+git apply "${script_dir_rel}/cilium_agent__service.yaml.patch"
+{ set +x; } 2>/dev/null

--- a/sync/sync.sh
+++ b/sync/sync.sh
@@ -16,6 +16,7 @@ helm dependency update helm/cilium/
 # Patches
 ./sync/patches/cleanup_kube_proxy/patch.sh
 ./sync/patches/eni/patch.sh
+./sync/patches/metrics_port/patch.sh
 ./sync/patches/image_registries/patch.sh
 ./sync/patches/readme/patch.sh
 ./sync/patches/values/patch.sh


### PR DESCRIPTION
<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- Restore agent metrics

Towards https://github.com/giantswarm/giantswarm/issues/33501

---

## Checklist

- [ ] I added a CHANGELOG entry
- [ ] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
