### PR TITLE
Add resource requests and limits to Hubble and Cilium Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Re-enable Cilium agent and operator metrics port.
+- Add resource requests and limits to Hubble UI and Relay.
+- Add resource requests and limits to Cilium Operator.
 
 ## [1.1.1] - 2025-05-20
 

--- a/diffs/helm__cilium__values.yaml.tmpl.patch
+++ b/diffs/helm__cilium__values.yaml.tmpl.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/cilium/install/kubernetes/cilium/values.yaml.tmpl b/helm/cilium/values.yaml.tmpl
-index 9d6ce1d..13b660e 100644
+index 9d6ce1d..ed32f0e 100644
 --- a/vendor/cilium/install/kubernetes/cilium/values.yaml.tmpl
 +++ b/helm/cilium/values.yaml.tmpl
 @@ -187,6 +187,7 @@ name: cilium
@@ -63,7 +63,7 @@ index 9d6ce1d..13b660e 100644
      # -- Roll out Hubble Relay pods automatically when configmap is updated.
      rollOutPods: false
      # -- Hubble-relay container image.
-@@ -1459,7 +1460,13 @@ hubble:
+@@ -1459,7 +1460,14 @@ hubble:
        useDigest: ${USE_DIGESTS}
        pullPolicy: "${PULL_POLICY}"
      # -- Specifies the resources for the hubble-relay pods
@@ -72,13 +72,14 @@ index 9d6ce1d..13b660e 100644
 +      requests:
 +        cpu: 100m
 +        memory: 128Mi
++        ephemeral-storage: 2Gi
 +      limits:
 +        memory: 512Mi
 +        ephemeral-storage: 2Gi
      # -- Number of replicas run for the hubble-relay deployment.
      replicas: 1
      # -- Affinity for hubble-replay
-@@ -1484,11 +1491,14 @@ hubble:
+@@ -1484,11 +1492,14 @@ hubble:
      # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      tolerations: []
      # -- Additional hubble-relay environment variables.
@@ -95,7 +96,7 @@ index 9d6ce1d..13b660e 100644
      # -- Labels to be added to hubble-relay pods
      podLabels: {}
      # PodDisruptionBudget settings
-@@ -1520,21 +1530,28 @@ hubble:
+@@ -1520,21 +1531,28 @@ hubble:
          # @schema
          maxUnavailable: 1
      # -- Additional hubble-relay volumes.
@@ -127,7 +128,7 @@ index 9d6ce1d..13b660e 100644
      # -- hubble-relay service configuration.
      service:
        # --- The type of service used for Hubble Relay access, either ClusterIP, NodePort or LoadBalancer.
-@@ -1621,7 +1638,7 @@ hubble:
+@@ -1621,7 +1639,7 @@ hubble:
      # -- Enable prometheus metrics for hubble-relay on the configured port at
      # /metrics
      prometheus:
@@ -136,7 +137,7 @@ index 9d6ce1d..13b660e 100644
        port: 9966
        serviceMonitor:
          # -- Enable service monitors.
-@@ -1660,7 +1677,7 @@ hubble:
+@@ -1660,7 +1678,7 @@ hubble:
        port: 6062
    ui:
      # -- Whether to enable the Hubble UI.
@@ -145,7 +146,7 @@ index 9d6ce1d..13b660e 100644
      standalone:
        # -- When true, it will allow installing the Hubble UI only, without checking dependencies.
        # It is useful if a cluster already has cilium and Hubble relay installed and you just
-@@ -1709,7 +1726,17 @@ hubble:
+@@ -1709,7 +1727,17 @@ hubble:
          useDigest: true
          pullPolicy: "${PULL_POLICY}"
        # -- Hubble-ui backend security context.
@@ -164,7 +165,7 @@ index 9d6ce1d..13b660e 100644
        # -- Additional hubble-ui backend environment variables.
        extraEnv: []
        # -- Additional hubble-ui backend volumes.
-@@ -1723,13 +1750,13 @@ hubble:
+@@ -1723,13 +1751,14 @@ hubble:
          # -- Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
          enabled: false
        # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
@@ -182,10 +183,11 @@ index 9d6ce1d..13b660e 100644
 +        requests:
 +          cpu: 100m
 +          memory: 64Mi
++          ephemeral-storage: 4Gi
      frontend:
        # -- Hubble-ui frontend image.
        image:
-@@ -1743,7 +1770,17 @@ hubble:
+@@ -1743,7 +1772,17 @@ hubble:
          useDigest: true
          pullPolicy: "${PULL_POLICY}"
        # -- Hubble-ui frontend security context.
@@ -204,7 +206,7 @@ index 9d6ce1d..13b660e 100644
        # -- Additional hubble-ui frontend environment variables.
        extraEnv: []
        # -- Additional hubble-ui frontend volumes.
-@@ -1751,13 +1788,13 @@ hubble:
+@@ -1751,13 +1790,14 @@ hubble:
        # -- Additional hubble-ui frontend volumeMounts.
        extraVolumeMounts: []
        # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
@@ -222,10 +224,11 @@ index 9d6ce1d..13b660e 100644
 +        requests:
 +          cpu: 100m
 +          memory: 64Mi
++          ephemeral-storage: 4Gi
        server:
          # -- Controls server listener for ipv6
          ipv6:
-@@ -1769,7 +1806,8 @@ hubble:
+@@ -1769,7 +1809,8 @@ hubble:
      # -- Additional labels to be added to 'hubble-ui' deployment object
      labels: {}
      # -- Annotations to be added to hubble-ui pods
@@ -235,7 +238,7 @@ index 9d6ce1d..13b660e 100644
      # -- Labels to be added to hubble-ui pods
      podLabels: {}
      # PodDisruptionBudget settings
-@@ -1815,9 +1853,13 @@ hubble:
+@@ -1815,9 +1856,13 @@ hubble:
          maxUnavailable: 1
      # -- Security context to be added to Hubble UI pods
      securityContext:
@@ -250,7 +253,7 @@ index 9d6ce1d..13b660e 100644
      # -- hubble-ui service configuration.
      service:
        # -- Annotations to be added for the Hubble UI service
-@@ -2047,9 +2089,9 @@ l2NeighDiscovery:
+@@ -2047,9 +2092,9 @@ l2NeighDiscovery:
  # -- Enable Layer 7 network policy.
  l7Proxy: true
  # -- Enable Local Redirect Policy.
@@ -262,7 +265,7 @@ index 9d6ce1d..13b660e 100644
  
  # logOptions allows you to define logging options. eg:
  # logOptions:
-@@ -2231,8 +2273,8 @@ pprof:
+@@ -2231,8 +2276,8 @@ pprof:
    port: 6060
  # -- Configure prometheus metrics on the configured port at /metrics
  prometheus:
@@ -273,7 +276,7 @@ index 9d6ce1d..13b660e 100644
    port: 9962
    serviceMonitor:
      # -- Enable service monitors.
-@@ -2791,7 +2833,9 @@ operator:
+@@ -2791,7 +2836,9 @@ operator:
    # -- Additional cilium-operator container arguments.
    extraArgs: []
    # -- Additional cilium-operator environment variables.
@@ -284,7 +287,7 @@ index 9d6ce1d..13b660e 100644
    # -- Additional cilium-operator hostPath mounts.
    extraHostPathMounts: []
    # - name: host-mnt-data
-@@ -2802,15 +2846,22 @@ operator:
+@@ -2802,15 +2849,22 @@ operator:
    #   mountPropagation: HostToContainer
  
    # -- Additional cilium-operator volumes.
@@ -310,7 +313,7 @@ index 9d6ce1d..13b660e 100644
    # -- Annotations to be added to cilium-operator pods
    podAnnotations: {}
    # -- Labels to be added to cilium-operator pods
-@@ -2819,7 +2870,7 @@ operator:
+@@ -2819,7 +2873,7 @@ operator:
    podDisruptionBudget:
      # -- enable PodDisruptionBudget
      # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
@@ -319,7 +322,7 @@ index 9d6ce1d..13b660e 100644
      # @schema
      # type: [null, integer, string]
      # @schema
-@@ -2833,17 +2884,26 @@ operator:
+@@ -2833,17 +2887,27 @@ operator:
      maxUnavailable: 1
    # -- cilium-operator resource limits & requests
    # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -337,6 +340,7 @@ index 9d6ce1d..13b660e 100644
 +    requests:
 +      cpu: 100m
 +      memory: 256Mi
++      ephemeral-storage: 2Gi
  
    # -- Security context to be added to cilium-operator pods
 -  securityContext: {}
@@ -355,7 +359,7 @@ index 9d6ce1d..13b660e 100644
  
    # -- Interval for endpoint garbage collection.
    endpointGCInterval: "5m0s"
-@@ -2863,7 +2923,7 @@ operator:
+@@ -2863,7 +2927,7 @@ operator:
    # -- Enable prometheus metrics for cilium-operator on the configured port at
    # /metrics
    prometheus:
@@ -364,7 +368,7 @@ index 9d6ce1d..13b660e 100644
      enabled: true
      port: 9963
      serviceMonitor:
-@@ -3836,3 +3896,11 @@ authentication:
+@@ -3836,3 +3900,11 @@ authentication:
  enableInternalTrafficPolicy: true
  # -- Enable LoadBalancer IP Address Management
  enableLBIPAM: true

--- a/diffs/helm__cilium__values.yaml.tmpl.patch
+++ b/diffs/helm__cilium__values.yaml.tmpl.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/cilium/install/kubernetes/cilium/values.yaml.tmpl b/helm/cilium/values.yaml.tmpl
-index 9d6ce1d..f970ee3 100644
+index 9d6ce1d..13b660e 100644
 --- a/vendor/cilium/install/kubernetes/cilium/values.yaml.tmpl
 +++ b/helm/cilium/values.yaml.tmpl
 @@ -187,6 +187,7 @@ name: cilium
@@ -63,7 +63,22 @@ index 9d6ce1d..f970ee3 100644
      # -- Roll out Hubble Relay pods automatically when configmap is updated.
      rollOutPods: false
      # -- Hubble-relay container image.
-@@ -1484,11 +1485,14 @@ hubble:
+@@ -1459,7 +1460,13 @@ hubble:
+       useDigest: ${USE_DIGESTS}
+       pullPolicy: "${PULL_POLICY}"
+     # -- Specifies the resources for the hubble-relay pods
+-    resources: {}
++    resources:
++      requests:
++        cpu: 100m
++        memory: 128Mi
++      limits:
++        memory: 512Mi
++        ephemeral-storage: 2Gi
+     # -- Number of replicas run for the hubble-relay deployment.
+     replicas: 1
+     # -- Affinity for hubble-replay
+@@ -1484,11 +1491,14 @@ hubble:
      # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      tolerations: []
      # -- Additional hubble-relay environment variables.
@@ -80,7 +95,7 @@ index 9d6ce1d..f970ee3 100644
      # -- Labels to be added to hubble-relay pods
      podLabels: {}
      # PodDisruptionBudget settings
-@@ -1520,21 +1524,28 @@ hubble:
+@@ -1520,21 +1530,28 @@ hubble:
          # @schema
          maxUnavailable: 1
      # -- Additional hubble-relay volumes.
@@ -112,7 +127,7 @@ index 9d6ce1d..f970ee3 100644
      # -- hubble-relay service configuration.
      service:
        # --- The type of service used for Hubble Relay access, either ClusterIP, NodePort or LoadBalancer.
-@@ -1621,7 +1632,7 @@ hubble:
+@@ -1621,7 +1638,7 @@ hubble:
      # -- Enable prometheus metrics for hubble-relay on the configured port at
      # /metrics
      prometheus:
@@ -121,7 +136,7 @@ index 9d6ce1d..f970ee3 100644
        port: 9966
        serviceMonitor:
          # -- Enable service monitors.
-@@ -1660,7 +1671,7 @@ hubble:
+@@ -1660,7 +1677,7 @@ hubble:
        port: 6062
    ui:
      # -- Whether to enable the Hubble UI.
@@ -130,7 +145,7 @@ index 9d6ce1d..f970ee3 100644
      standalone:
        # -- When true, it will allow installing the Hubble UI only, without checking dependencies.
        # It is useful if a cluster already has cilium and Hubble relay installed and you just
-@@ -1709,7 +1720,17 @@ hubble:
+@@ -1709,7 +1726,17 @@ hubble:
          useDigest: true
          pullPolicy: "${PULL_POLICY}"
        # -- Hubble-ui backend security context.
@@ -149,7 +164,28 @@ index 9d6ce1d..f970ee3 100644
        # -- Additional hubble-ui backend environment variables.
        extraEnv: []
        # -- Additional hubble-ui backend volumes.
-@@ -1743,7 +1764,17 @@ hubble:
+@@ -1723,13 +1750,13 @@ hubble:
+         # -- Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+         enabled: false
+       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
+-      resources: {}
+-      #   limits:
+-      #     cpu: 1000m
+-      #     memory: 1024M
+-      #   requests:
+-      #     cpu: 100m
+-      #     memory: 64Mi
++      resources:
++        limits:
++          memory: 1024M
++          ephemeral-storage: 4Gi
++        requests:
++          cpu: 100m
++          memory: 64Mi
+     frontend:
+       # -- Hubble-ui frontend image.
+       image:
+@@ -1743,7 +1770,17 @@ hubble:
          useDigest: true
          pullPolicy: "${PULL_POLICY}"
        # -- Hubble-ui frontend security context.
@@ -168,7 +204,28 @@ index 9d6ce1d..f970ee3 100644
        # -- Additional hubble-ui frontend environment variables.
        extraEnv: []
        # -- Additional hubble-ui frontend volumes.
-@@ -1769,7 +1800,8 @@ hubble:
+@@ -1751,13 +1788,13 @@ hubble:
+       # -- Additional hubble-ui frontend volumeMounts.
+       extraVolumeMounts: []
+       # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
+-      resources: {}
+-      #   limits:
+-      #     cpu: 1000m
+-      #     memory: 1024M
+-      #   requests:
+-      #     cpu: 100m
+-      #     memory: 64Mi
++      resources:
++        limits:
++          memory: 1024M
++          ephemeral-storage: 4Gi
++        requests:
++          cpu: 100m
++          memory: 64Mi
+       server:
+         # -- Controls server listener for ipv6
+         ipv6:
+@@ -1769,7 +1806,8 @@ hubble:
      # -- Additional labels to be added to 'hubble-ui' deployment object
      labels: {}
      # -- Annotations to be added to hubble-ui pods
@@ -178,7 +235,7 @@ index 9d6ce1d..f970ee3 100644
      # -- Labels to be added to hubble-ui pods
      podLabels: {}
      # PodDisruptionBudget settings
-@@ -1815,9 +1847,13 @@ hubble:
+@@ -1815,9 +1853,13 @@ hubble:
          maxUnavailable: 1
      # -- Security context to be added to Hubble UI pods
      securityContext:
@@ -193,7 +250,7 @@ index 9d6ce1d..f970ee3 100644
      # -- hubble-ui service configuration.
      service:
        # -- Annotations to be added for the Hubble UI service
-@@ -2047,9 +2083,9 @@ l2NeighDiscovery:
+@@ -2047,9 +2089,9 @@ l2NeighDiscovery:
  # -- Enable Layer 7 network policy.
  l7Proxy: true
  # -- Enable Local Redirect Policy.
@@ -205,7 +262,7 @@ index 9d6ce1d..f970ee3 100644
  
  # logOptions allows you to define logging options. eg:
  # logOptions:
-@@ -2231,8 +2267,8 @@ pprof:
+@@ -2231,8 +2273,8 @@ pprof:
    port: 6060
  # -- Configure prometheus metrics on the configured port at /metrics
  prometheus:
@@ -216,7 +273,7 @@ index 9d6ce1d..f970ee3 100644
    port: 9962
    serviceMonitor:
      # -- Enable service monitors.
-@@ -2791,7 +2827,9 @@ operator:
+@@ -2791,7 +2833,9 @@ operator:
    # -- Additional cilium-operator container arguments.
    extraArgs: []
    # -- Additional cilium-operator environment variables.
@@ -227,7 +284,7 @@ index 9d6ce1d..f970ee3 100644
    # -- Additional cilium-operator hostPath mounts.
    extraHostPathMounts: []
    # - name: host-mnt-data
-@@ -2802,15 +2840,22 @@ operator:
+@@ -2802,15 +2846,22 @@ operator:
    #   mountPropagation: HostToContainer
  
    # -- Additional cilium-operator volumes.
@@ -253,7 +310,7 @@ index 9d6ce1d..f970ee3 100644
    # -- Annotations to be added to cilium-operator pods
    podAnnotations: {}
    # -- Labels to be added to cilium-operator pods
-@@ -2819,7 +2864,7 @@ operator:
+@@ -2819,7 +2870,7 @@ operator:
    podDisruptionBudget:
      # -- enable PodDisruptionBudget
      # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
@@ -262,8 +319,24 @@ index 9d6ce1d..f970ee3 100644
      # @schema
      # type: [null, integer, string]
      # @schema
-@@ -2842,8 +2887,17 @@ operator:
-   #     memory: 128Mi
+@@ -2833,17 +2884,26 @@ operator:
+     maxUnavailable: 1
+   # -- cilium-operator resource limits & requests
+   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+-  resources: {}
+-  #   limits:
+-  #     cpu: 1000m
+-  #     memory: 1Gi
+-  #   requests:
+-  #     cpu: 100m
+-  #     memory: 128Mi
++  resources:
++    limits:
++      memory: 1Gi
++      ephemeral-storage: 2Gi
++    requests:
++      cpu: 100m
++      memory: 256Mi
  
    # -- Security context to be added to cilium-operator pods
 -  securityContext: {}
@@ -282,7 +355,7 @@ index 9d6ce1d..f970ee3 100644
  
    # -- Interval for endpoint garbage collection.
    endpointGCInterval: "5m0s"
-@@ -2863,7 +2917,7 @@ operator:
+@@ -2863,7 +2923,7 @@ operator:
    # -- Enable prometheus metrics for cilium-operator on the configured port at
    # /metrics
    prometheus:
@@ -291,7 +364,7 @@ index 9d6ce1d..f970ee3 100644
      enabled: true
      port: 9963
      serviceMonitor:
-@@ -3836,3 +3890,11 @@ authentication:
+@@ -3836,3 +3896,11 @@ authentication:
  enableInternalTrafficPolicy: true
  # -- Enable LoadBalancer IP Address Management
  enableLBIPAM: true

--- a/helm/cilium/README.md
+++ b/helm/cilium/README.md
@@ -543,7 +543,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor hubble-relay |
 | hubble.relay.prometheus.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor hubble-relay |
 | hubble.relay.replicas | int | `1` | Number of replicas run for the hubble-relay deployment. |
-| hubble.relay.resources | object | `{}` | Specifies the resources for the hubble-relay pods |
+| hubble.relay.resources | object | `{"limits":{"ephemeral-storage":"2Gi","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Specifies the resources for the hubble-relay pods |
 | hubble.relay.retryTimeout | string | `nil` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
 | hubble.relay.rollOutPods | bool | `false` | Roll out Hubble Relay pods automatically when configmap is updated. |
 | hubble.relay.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | hubble-relay container security context |
@@ -591,7 +591,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.backend.image | object | `{"digest":"sha256:a034b7e98e6ea796ed26df8f4e71f83fc16465a19d166eff67a03b822c0bfa15","override":null,"pullPolicy":"IfNotPresent","repository":"giantswarm/hubble-ui-backend","tag":"v0.13.2","useDigest":true}` | Hubble-ui backend image. |
 | hubble.ui.backend.livenessProbe.enabled | bool | `false` | Enable liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+) |
 | hubble.ui.backend.readinessProbe.enabled | bool | `false` | Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+) |
-| hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
+| hubble.ui.backend.resources | object | `{"limits":{"ephemeral-storage":"4Gi","memory":"1024M"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.backend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Hubble-ui backend security context. |
 | hubble.ui.baseUrl | string | `"/"` | Defines base url prefix for all hubble-ui http requests. It needs to be changed in case if ingress for hubble-ui is configured under some sub-path. Trailing `/` is required for custom path, ex. `/service-map/` |
 | hubble.ui.enabled | bool | `true` | Whether to enable the Hubble UI. |
@@ -599,7 +599,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.frontend.extraVolumeMounts | list | `[]` | Additional hubble-ui frontend volumeMounts. |
 | hubble.ui.frontend.extraVolumes | list | `[]` | Additional hubble-ui frontend volumes. |
 | hubble.ui.frontend.image | object | `{"digest":"sha256:9e37c1296b802830834cc87342a9182ccbb71ffebb711971e849221bd9d59392","override":null,"pullPolicy":"IfNotPresent","repository":"giantswarm/hubble-ui","tag":"v0.13.2","useDigest":true}` | Hubble-ui frontend image. |
-| hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
+| hubble.ui.frontend.resources | object | `{"limits":{"ephemeral-storage":"4Gi","memory":"1024M"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.frontend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsNonRoot":true,"runAsUser":101,"seccompProfile":{"type":"RuntimeDefault"}}` | Hubble-ui frontend security context. |
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"labels":{},"tls":[]}` | hubble-ui ingress configuration. |
@@ -790,7 +790,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.prometheus.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor cilium-operator |
 | operator.removeNodeTaints | bool | `true` | Remove Cilium node taint from Kubernetes nodes that have a healthy Cilium pod running. |
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |
-| operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| operator.resources | object | `{"limits":{"ephemeral-storage":"2Gi","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context to be added to cilium-operator pods |
 | operator.setNodeNetworkStatus | bool | `true` | Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod. |

--- a/helm/cilium/README.md
+++ b/helm/cilium/README.md
@@ -543,7 +543,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor hubble-relay |
 | hubble.relay.prometheus.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor hubble-relay |
 | hubble.relay.replicas | int | `1` | Number of replicas run for the hubble-relay deployment. |
-| hubble.relay.resources | object | `{"limits":{"ephemeral-storage":"2Gi","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Specifies the resources for the hubble-relay pods |
+| hubble.relay.resources | object | `{"limits":{"ephemeral-storage":"2Gi","memory":"512Mi"},"requests":{"cpu":"100m","ephemeral-storage":"2Gi","memory":"128Mi"}}` | Specifies the resources for the hubble-relay pods |
 | hubble.relay.retryTimeout | string | `nil` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
 | hubble.relay.rollOutPods | bool | `false` | Roll out Hubble Relay pods automatically when configmap is updated. |
 | hubble.relay.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | hubble-relay container security context |
@@ -591,7 +591,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.backend.image | object | `{"digest":"sha256:a034b7e98e6ea796ed26df8f4e71f83fc16465a19d166eff67a03b822c0bfa15","override":null,"pullPolicy":"IfNotPresent","repository":"giantswarm/hubble-ui-backend","tag":"v0.13.2","useDigest":true}` | Hubble-ui backend image. |
 | hubble.ui.backend.livenessProbe.enabled | bool | `false` | Enable liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+) |
 | hubble.ui.backend.readinessProbe.enabled | bool | `false` | Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+) |
-| hubble.ui.backend.resources | object | `{"limits":{"ephemeral-storage":"4Gi","memory":"1024M"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
+| hubble.ui.backend.resources | object | `{"limits":{"ephemeral-storage":"4Gi","memory":"1024M"},"requests":{"cpu":"100m","ephemeral-storage":"4Gi","memory":"64Mi"}}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.backend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Hubble-ui backend security context. |
 | hubble.ui.baseUrl | string | `"/"` | Defines base url prefix for all hubble-ui http requests. It needs to be changed in case if ingress for hubble-ui is configured under some sub-path. Trailing `/` is required for custom path, ex. `/service-map/` |
 | hubble.ui.enabled | bool | `true` | Whether to enable the Hubble UI. |
@@ -599,7 +599,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.frontend.extraVolumeMounts | list | `[]` | Additional hubble-ui frontend volumeMounts. |
 | hubble.ui.frontend.extraVolumes | list | `[]` | Additional hubble-ui frontend volumes. |
 | hubble.ui.frontend.image | object | `{"digest":"sha256:9e37c1296b802830834cc87342a9182ccbb71ffebb711971e849221bd9d59392","override":null,"pullPolicy":"IfNotPresent","repository":"giantswarm/hubble-ui","tag":"v0.13.2","useDigest":true}` | Hubble-ui frontend image. |
-| hubble.ui.frontend.resources | object | `{"limits":{"ephemeral-storage":"4Gi","memory":"1024M"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
+| hubble.ui.frontend.resources | object | `{"limits":{"ephemeral-storage":"4Gi","memory":"1024M"},"requests":{"cpu":"100m","ephemeral-storage":"4Gi","memory":"64Mi"}}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.frontend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":101,"runAsNonRoot":true,"runAsUser":101,"seccompProfile":{"type":"RuntimeDefault"}}` | Hubble-ui frontend security context. |
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"labels":{},"tls":[]}` | hubble-ui ingress configuration. |
@@ -790,7 +790,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.prometheus.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor cilium-operator |
 | operator.removeNodeTaints | bool | `true` | Remove Cilium node taint from Kubernetes nodes that have a healthy Cilium pod running. |
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |
-| operator.resources | object | `{"limits":{"ephemeral-storage":"2Gi","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| operator.resources | object | `{"limits":{"ephemeral-storage":"2Gi","memory":"1Gi"},"requests":{"cpu":"100m","ephemeral-storage":"2Gi","memory":"256Mi"}}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context to be added to cilium-operator pods |
 | operator.setNodeNetworkStatus | bool | `true` | Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod. |

--- a/helm/cilium/values.schema.json
+++ b/helm/cilium/values.schema.json
@@ -3184,6 +3184,9 @@
                     "cpu": {
                       "type": "string"
                     },
+                    "ephemeral-storage": {
+                      "type": "string"
+                    },
                     "memory": {
                       "type": "string"
                     }
@@ -3492,6 +3495,9 @@
                         "cpu": {
                           "type": "string"
                         },
+                        "ephemeral-storage": {
+                          "type": "string"
+                        },
                         "memory": {
                           "type": "string"
                         }
@@ -3609,6 +3615,9 @@
                     "requests": {
                       "properties": {
                         "cpu": {
+                          "type": "string"
+                        },
+                        "ephemeral-storage": {
                           "type": "string"
                         },
                         "memory": {
@@ -4921,6 +4930,9 @@
             "requests": {
               "properties": {
                 "cpu": {
+                  "type": "string"
+                },
+                "ephemeral-storage": {
                   "type": "string"
                 },
                 "memory": {

--- a/helm/cilium/values.schema.json
+++ b/helm/cilium/values.schema.json
@@ -3167,6 +3167,30 @@
               "type": "integer"
             },
             "resources": {
+              "properties": {
+                "limits": {
+                  "properties": {
+                    "ephemeral-storage": {
+                      "type": "string"
+                    },
+                    "memory": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "requests": {
+                  "properties": {
+                    "cpu": {
+                      "type": "string"
+                    },
+                    "memory": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
               "type": "object"
             },
             "retryTimeout": {
@@ -3451,6 +3475,30 @@
                   "type": "object"
                 },
                 "resources": {
+                  "properties": {
+                    "limits": {
+                      "properties": {
+                        "ephemeral-storage": {
+                          "type": "string"
+                        },
+                        "memory": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "properties": {
+                        "cpu": {
+                          "type": "string"
+                        },
+                        "memory": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
                   "type": "object"
                 },
                 "securityContext": {
@@ -3546,6 +3594,30 @@
                   "type": "object"
                 },
                 "resources": {
+                  "properties": {
+                    "limits": {
+                      "properties": {
+                        "ephemeral-storage": {
+                          "type": "string"
+                        },
+                        "memory": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "properties": {
+                        "cpu": {
+                          "type": "string"
+                        },
+                        "memory": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
                   "type": "object"
                 },
                 "securityContext": {
@@ -4834,6 +4906,30 @@
           "type": "integer"
         },
         "resources": {
+          "properties": {
+            "limits": {
+              "properties": {
+                "ephemeral-storage": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "requests": {
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
           "type": "object"
         },
         "rollOutPods": {

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -1455,6 +1455,7 @@ hubble:
       requests:
         cpu: 100m
         memory: 128Mi
+        ephemeral-storage: 2Gi
       limits:
         memory: 512Mi
         ephemeral-storage: 2Gi
@@ -1748,6 +1749,7 @@ hubble:
         requests:
           cpu: 100m
           memory: 64Mi
+          ephemeral-storage: 4Gi
     frontend:
       # -- Hubble-ui frontend image.
       image:
@@ -1786,6 +1788,7 @@ hubble:
         requests:
           cpu: 100m
           memory: 64Mi
+          ephemeral-storage: 4Gi
       server:
         # -- Controls server listener for ipv6
         ipv6:
@@ -2873,6 +2876,7 @@ operator:
     requests:
       cpu: 100m
       memory: 256Mi
+      ephemeral-storage: 2Gi
   # -- Security context to be added to cilium-operator pods
   securityContext:
     allowPrivilegeEscalation: false

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -1451,7 +1451,13 @@ hubble:
       useDigest: true
       pullPolicy: "IfNotPresent"
     # -- Specifies the resources for the hubble-relay pods
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+        ephemeral-storage: 2Gi
     # -- Number of replicas run for the hubble-relay deployment.
     replicas: 1
     # -- Affinity for hubble-replay
@@ -1735,13 +1741,13 @@ hubble:
         # -- Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
         enabled: false
       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
-      resources: {}
-      #   limits:
-      #     cpu: 1000m
-      #     memory: 1024M
-      #   requests:
-      #     cpu: 100m
-      #     memory: 64Mi
+      resources:
+        limits:
+          memory: 1024M
+          ephemeral-storage: 4Gi
+        requests:
+          cpu: 100m
+          memory: 64Mi
     frontend:
       # -- Hubble-ui frontend image.
       image:
@@ -1773,13 +1779,13 @@ hubble:
       # -- Additional hubble-ui frontend volumeMounts.
       extraVolumeMounts: []
       # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
-      resources: {}
-      #   limits:
-      #     cpu: 1000m
-      #     memory: 1024M
-      #   requests:
-      #     cpu: 100m
-      #     memory: 64Mi
+      resources:
+        limits:
+          memory: 1024M
+          ephemeral-storage: 4Gi
+        requests:
+          cpu: 100m
+          memory: 64Mi
       server:
         # -- Controls server listener for ipv6
         ipv6:
@@ -2860,14 +2866,13 @@ operator:
     maxUnavailable: 1
   # -- cilium-operator resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  resources: {}
-  #   limits:
-  #     cpu: 1000m
-  #     memory: 1Gi
-  #   requests:
-  #     cpu: 100m
-  #     memory: 128Mi
-
+  resources:
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 2Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
   # -- Security context to be added to cilium-operator pods
   securityContext:
     allowPrivilegeEscalation: false

--- a/helm/cilium/values.yaml.tmpl
+++ b/helm/cilium/values.yaml.tmpl
@@ -1464,6 +1464,7 @@ hubble:
       requests:
         cpu: 100m
         memory: 128Mi
+        ephemeral-storage: 2Gi
       limits:
         memory: 512Mi
         ephemeral-storage: 2Gi
@@ -1757,6 +1758,7 @@ hubble:
         requests:
           cpu: 100m
           memory: 64Mi
+          ephemeral-storage: 4Gi
     frontend:
       # -- Hubble-ui frontend image.
       image:
@@ -1795,6 +1797,7 @@ hubble:
         requests:
           cpu: 100m
           memory: 64Mi
+          ephemeral-storage: 4Gi
       server:
         # -- Controls server listener for ipv6
         ipv6:
@@ -2891,6 +2894,7 @@ operator:
     requests:
       cpu: 100m
       memory: 256Mi
+      ephemeral-storage: 2Gi
 
   # -- Security context to be added to cilium-operator pods
   securityContext:

--- a/helm/cilium/values.yaml.tmpl
+++ b/helm/cilium/values.yaml.tmpl
@@ -1460,7 +1460,13 @@ hubble:
       useDigest: ${USE_DIGESTS}
       pullPolicy: "${PULL_POLICY}"
     # -- Specifies the resources for the hubble-relay pods
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+        ephemeral-storage: 2Gi
     # -- Number of replicas run for the hubble-relay deployment.
     replicas: 1
     # -- Affinity for hubble-replay
@@ -1744,13 +1750,13 @@ hubble:
         # -- Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
         enabled: false
       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
-      resources: {}
-      #   limits:
-      #     cpu: 1000m
-      #     memory: 1024M
-      #   requests:
-      #     cpu: 100m
-      #     memory: 64Mi
+      resources:
+        limits:
+          memory: 1024M
+          ephemeral-storage: 4Gi
+        requests:
+          cpu: 100m
+          memory: 64Mi
     frontend:
       # -- Hubble-ui frontend image.
       image:
@@ -1782,13 +1788,13 @@ hubble:
       # -- Additional hubble-ui frontend volumeMounts.
       extraVolumeMounts: []
       # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
-      resources: {}
-      #   limits:
-      #     cpu: 1000m
-      #     memory: 1024M
-      #   requests:
-      #     cpu: 100m
-      #     memory: 64Mi
+      resources:
+        limits:
+          memory: 1024M
+          ephemeral-storage: 4Gi
+        requests:
+          cpu: 100m
+          memory: 64Mi
       server:
         # -- Controls server listener for ipv6
         ipv6:
@@ -2878,13 +2884,13 @@ operator:
     maxUnavailable: 1
   # -- cilium-operator resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  resources: {}
-  #   limits:
-  #     cpu: 1000m
-  #     memory: 1Gi
-  #   requests:
-  #     cpu: 100m
-  #     memory: 128Mi
+  resources:
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 2Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
   # -- Security context to be added to cilium-operator pods
   securityContext:

--- a/sync/patches/values/values.yaml.tmpl
+++ b/sync/patches/values/values.yaml.tmpl
@@ -1464,6 +1464,7 @@ hubble:
       requests:
         cpu: 100m
         memory: 128Mi
+        ephemeral-storage: 2Gi
       limits:
         memory: 512Mi
         ephemeral-storage: 2Gi
@@ -1757,6 +1758,7 @@ hubble:
         requests:
           cpu: 100m
           memory: 64Mi
+          ephemeral-storage: 4Gi
     frontend:
       # -- Hubble-ui frontend image.
       image:
@@ -1795,6 +1797,7 @@ hubble:
         requests:
           cpu: 100m
           memory: 64Mi
+          ephemeral-storage: 4Gi
       server:
         # -- Controls server listener for ipv6
         ipv6:
@@ -2891,6 +2894,7 @@ operator:
     requests:
       cpu: 100m
       memory: 256Mi
+      ephemeral-storage: 2Gi
 
   # -- Security context to be added to cilium-operator pods
   securityContext:

--- a/sync/patches/values/values.yaml.tmpl
+++ b/sync/patches/values/values.yaml.tmpl
@@ -1460,7 +1460,13 @@ hubble:
       useDigest: ${USE_DIGESTS}
       pullPolicy: "${PULL_POLICY}"
     # -- Specifies the resources for the hubble-relay pods
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+        ephemeral-storage: 2Gi
     # -- Number of replicas run for the hubble-relay deployment.
     replicas: 1
     # -- Affinity for hubble-replay
@@ -1744,13 +1750,13 @@ hubble:
         # -- Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
         enabled: false
       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
-      resources: {}
-      #   limits:
-      #     cpu: 1000m
-      #     memory: 1024M
-      #   requests:
-      #     cpu: 100m
-      #     memory: 64Mi
+      resources:
+        limits:
+          memory: 1024M
+          ephemeral-storage: 4Gi
+        requests:
+          cpu: 100m
+          memory: 64Mi
     frontend:
       # -- Hubble-ui frontend image.
       image:
@@ -1782,13 +1788,13 @@ hubble:
       # -- Additional hubble-ui frontend volumeMounts.
       extraVolumeMounts: []
       # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
-      resources: {}
-      #   limits:
-      #     cpu: 1000m
-      #     memory: 1024M
-      #   requests:
-      #     cpu: 100m
-      #     memory: 64Mi
+      resources:
+        limits:
+          memory: 1024M
+          ephemeral-storage: 4Gi
+        requests:
+          cpu: 100m
+          memory: 64Mi
       server:
         # -- Controls server listener for ipv6
         ipv6:
@@ -2878,13 +2884,13 @@ operator:
     maxUnavailable: 1
   # -- cilium-operator resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  resources: {}
-  #   limits:
-  #     cpu: 1000m
-  #     memory: 1Gi
-  #   requests:
-  #     cpu: 100m
-  #     memory: 128Mi
+  resources:
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 2Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
   # -- Security context to be added to cilium-operator pods
   securityContext:

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,2 +1,3 @@
 kubeconfig
+report.json
 results.json


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- Adds resource requests and limits to Hubble UI and Relay
- Adds resource requests and limits to Cilium Operator

Towards https://github.com/giantswarm/giantswarm/issues/31475 and https://github.com/giantswarm/giantswarm/issues/31747

---

## Checklist

- [x] I added a CHANGELOG entry
- [ ] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
