### PR TITLE
Enable ctAccounting by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable conntrack accounting in Cilium agent by default.
+
 ## [1.2.0] - 2025-06-02
 
 ### Changed

--- a/diffs/helm__cilium__values.yaml.tmpl.patch
+++ b/diffs/helm__cilium__values.yaml.tmpl.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/cilium/install/kubernetes/cilium/values.yaml.tmpl b/helm/cilium/values.yaml.tmpl
-index 9d6ce1d..ed32f0e 100644
+index 9d6ce1d..123dd27 100644
 --- a/vendor/cilium/install/kubernetes/cilium/values.yaml.tmpl
 +++ b/helm/cilium/values.yaml.tmpl
 @@ -187,6 +187,7 @@ name: cilium
@@ -9,6 +9,15 @@ index 9d6ce1d..ed32f0e 100644
 +  registry: gsoci.azurecr.io
    # @schema
    # type: [null, string]
+   # @schema
+@@ -485,7 +486,7 @@ bpf:
+   # @default -- `524288`
+   authMapMax: ~
+   # -- Enable CT accounting for packets and bytes
+-  ctAccounting: false
++  ctAccounting: true
+   # @schema
+   # type: [null, integer]
    # @schema
 @@ -564,7 +565,7 @@ bpf:
    # @schema

--- a/helm/cilium/README.md
+++ b/helm/cilium/README.md
@@ -127,7 +127,7 @@ contributors across the globe, there is almost always someone available to help.
 | bgpControlPlane.statusReport.enabled | bool | `true` | Enable/Disable BGPv2 status reporting It is recommended to enable status reporting in general, but if you have any issue such as high API server load, you can disable it by setting this to false. |
 | bpf.authMapMax | int | `524288` | Configure the maximum number of entries in auth map. |
 | bpf.autoMount.enabled | bool | `true` | Enable automatic mount of BPF filesystem When `autoMount` is enabled, the BPF filesystem is mounted at `bpf.root` path on the underlying host and inside the cilium agent pod. If users disable `autoMount`, it's expected that users have mounted bpffs filesystem at the specified `bpf.root` volume, and then the volume will be mounted inside the cilium agent pod at the same path. |
-| bpf.ctAccounting | bool | `false` | Enable CT accounting for packets and bytes |
+| bpf.ctAccounting | bool | `true` | Enable CT accounting for packets and bytes |
 | bpf.ctAnyMax | int | `262144` | Configure the maximum number of entries for the non-TCP connection tracking table. |
 | bpf.ctTcpMax | int | `524288` | Configure the maximum number of entries in the TCP connection tracking table. |
 | bpf.datapathMode | string | `veth` | Mode for Pod devices for the core datapath (veth, netkit, netkit-l2, lb-only) |

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -485,7 +485,7 @@ bpf:
   # @default -- `524288`
   authMapMax: ~
   # -- Enable CT accounting for packets and bytes
-  ctAccounting: false
+  ctAccounting: true
   # @schema
   # type: [null, integer]
   # @schema

--- a/helm/cilium/values.yaml.tmpl
+++ b/helm/cilium/values.yaml.tmpl
@@ -486,7 +486,7 @@ bpf:
   # @default -- `524288`
   authMapMax: ~
   # -- Enable CT accounting for packets and bytes
-  ctAccounting: false
+  ctAccounting: true
   # @schema
   # type: [null, integer]
   # @schema

--- a/sync/patches/values/values.yaml.tmpl
+++ b/sync/patches/values/values.yaml.tmpl
@@ -486,7 +486,7 @@ bpf:
   # @default -- `524288`
   authMapMax: ~
   # -- Enable CT accounting for packets and bytes
-  ctAccounting: false
+  ctAccounting: true
   # @schema
   # type: [null, integer]
   # @schema


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- Enable ctAccounting by default
  From 1.16, Conntrack accounting was disabled by default. This brings back the behavior of previous versions.
  Unfortunately this can't be enabled in 1.16, so we enable it by default from 1.17 on.

---

## Checklist

- [ ] I added a CHANGELOG entry
- [ ] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
