### PR TITLE
Increase Cilium operator resource limits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Cilium to [v1.17.6](https://github.com/cilium/cilium/releases/tag/v1.17.6).
 - Updated E2E tests to use apptest-framework v1.14.0
+- Restore hostPort.enabled flag.
+- Increase Cilium operator resource limits.
+
+### Removed
+
+- Remove deprecated "partial" mode from Kube Proxy Replacement options.
 
 ## [1.2.1] - 2025-06-10
 

--- a/diffs/helm__cilium__values.yaml.tmpl.patch
+++ b/diffs/helm__cilium__values.yaml.tmpl.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/cilium/install/kubernetes/cilium/values.yaml.tmpl b/helm/cilium/values.yaml.tmpl
-index 1911033..0b61ef7 100644
+index 1911033..8423e81 100644
 --- a/vendor/cilium/install/kubernetes/cilium/values.yaml.tmpl
 +++ b/helm/cilium/values.yaml.tmpl
 @@ -187,6 +187,7 @@ name: cilium
@@ -344,8 +344,8 @@ index 1911033..0b61ef7 100644
 -  #     memory: 128Mi
 +  resources:
 +    limits:
-+      memory: 1Gi
-+      ephemeral-storage: 2Gi
++      memory: 2Gi
++      ephemeral-storage: 4Gi
 +    requests:
 +      cpu: 100m
 +      memory: 256Mi

--- a/helm/cilium/README.md
+++ b/helm/cilium/README.md
@@ -790,7 +790,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.prometheus.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor cilium-operator |
 | operator.removeNodeTaints | bool | `true` | Remove Cilium node taint from Kubernetes nodes that have a healthy Cilium pod running. |
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |
-| operator.resources | object | `{"limits":{"ephemeral-storage":"2Gi","memory":"1Gi"},"requests":{"cpu":"100m","ephemeral-storage":"2Gi","memory":"256Mi"}}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| operator.resources | object | `{"limits":{"ephemeral-storage":"4Gi","memory":"2Gi"},"requests":{"cpu":"100m","ephemeral-storage":"2Gi","memory":"256Mi"}}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context to be added to cilium-operator pods |
 | operator.setNodeNetworkStatus | bool | `true` | Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod. |

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -2868,8 +2868,8 @@ operator:
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      memory: 1Gi
-      ephemeral-storage: 2Gi
+      memory: 2Gi
+      ephemeral-storage: 4Gi
     requests:
       cpu: 100m
       memory: 256Mi

--- a/helm/cilium/values.yaml.tmpl
+++ b/helm/cilium/values.yaml.tmpl
@@ -2886,8 +2886,8 @@ operator:
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      memory: 1Gi
-      ephemeral-storage: 2Gi
+      memory: 2Gi
+      ephemeral-storage: 4Gi
     requests:
       cpu: 100m
       memory: 256Mi

--- a/sync/patches/values/values.yaml.tmpl
+++ b/sync/patches/values/values.yaml.tmpl
@@ -2886,8 +2886,8 @@ operator:
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      memory: 1Gi
-      ephemeral-storage: 2Gi
+      memory: 2Gi
+      ephemeral-storage: 4Gi
     requests:
       cpu: 100m
       memory: 256Mi

--- a/sync/sync.sh
+++ b/sync/sync.sh
@@ -46,3 +46,6 @@ for f in $(git --no-pager diff --no-exit-code --no-color --no-index vendor/ciliu
                 exit $ret
         fi
 done
+
+# Print upstream changelog
+awk '/^##/ { if (++count == 2) exit } count >= 1' vendor/cilium/CHANGELOG.md

--- a/vendir.yml
+++ b/vendir.yml
@@ -10,6 +10,7 @@ directories:
           ref: &version "v1.17.6"
         includePaths:
           - install/kubernetes/**/*
+          - CHANGELOG.md
           - Makefile.defs
           - Makefile.quiet
           - VERSION


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- Increase Cilium opreator resource limits
- Also add entries to changelog from previous PR.
- Print Upstream CHANGELOG as well at the end of the sync to be able to incorporate some into ours

---

## Checklist

- [ ] I added a CHANGELOG entry
- [ ] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
