### PR TITLE
Improve the k8s service host autodiscovery mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve the k8s service host autodiscovery mechanism
+
 ## [1.2.2] - 2025-07-23
 
 ### Changed

--- a/helm/cilium/templates/_helpers.tpl
+++ b/helm/cilium/templates/_helpers.tpl
@@ -141,8 +141,8 @@ To override the namespace and configMap when using `auto`:
   {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
   {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}
   {{- if eq .Values.k8sServiceHost "auto" }}
-    {{- if lookup "v1" "ConfigMap" $configmapNamespace $configmapName }}
-      {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
+    {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
+    {{- if $configmap }}
       {{- $kubeconfig := get $configmap.data "kubeconfig" }}
       {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
       {{- $uri := (split "https://" $k8sServer)._1 | trim }}

--- a/helm/cilium/templates/_helpers.tpl
+++ b/helm/cilium/templates/_helpers.tpl
@@ -140,12 +140,16 @@ To override the namespace and configMap when using `auto`:
 {{- define "k8sServiceHost" }}
   {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
   {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}
-  {{- if and (eq .Values.k8sServiceHost "auto") (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
-    {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
-    {{- $kubeconfig := get $configmap.data "kubeconfig" }}
-    {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
-    {{- $uri := (split "https://" $k8sServer)._1 | trim }}
-    {{- (split ":" $uri)._0 | quote }}
+  {{- if eq .Values.k8sServiceHost "auto" }}
+    {{- if lookup "v1" "ConfigMap" $configmapNamespace $configmapName }}
+      {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
+      {{- $kubeconfig := get $configmap.data "kubeconfig" }}
+      {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
+      {{- $uri := (split "https://" $k8sServer)._1 | trim }}
+      {{- (split ":" $uri)._0 | quote }}
+    {{- else }}
+      {{- fail (printf "ConfigMap %s/%s not found, please create it or set k8sServiceHost to a valid value" $configmapNamespace $configmapName) }}
+    {{- end }}
   {{- else }}
     {{- .Values.k8sServiceHost | quote }}
   {{- end }}

--- a/sync/patches/k8sservicehost_auto/README.md
+++ b/sync/patches/k8sservicehost_auto/README.md
@@ -1,0 +1,43 @@
+# Patch for k8sServiceHost "auto" handling
+
+Remove this once https://github.com/cilium/cilium/pull/41291 has been released
+
+## How is the patch generated?
+
+First, stage the changes (in `./helm`) and the run:
+
+> [!TIP]
+> Skip the `-R` flags if the changes were added.
+
+```bash
+git --no-pager diff -R helm/cilium/templates/_helpers.tpl \
+        > sync/patches/k8sservicehost_auto/_helpers.tpl.patch
+```
+
+## What is the patched change?
+
+In case something goes wrong this is the raw change, in file `helm/cilium/templates/_helpers.tpl`, replace:
+
+```
+  {{- if and (eq .Values.k8sServiceHost "auto") (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
+    {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
+    {{- $kubeconfig := get $configmap.data "kubeconfig" }}
+    {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
+    {{- $uri := (split "https://" $k8sServer)._1 | trim }}
+    {{- (split ":" $uri)._0 | quote }}
+```
+
+with:
+
+```
+  {{- if eq .Values.k8sServiceHost "auto" }}
+    {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
+    {{- if $configmap }}
+      {{- $kubeconfig := get $configmap.data "kubeconfig" }}
+      {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
+      {{- $uri := (split "https://" $k8sServer)._1 | trim }}
+      {{- (split ":" $uri)._0 | quote }}
+    {{- else }}
+      {{- fail (printf "ConfigMap %s/%s not found, please create it or set k8sServiceHost to a valid value" $configmapNamespace $configmapName) }}
+    {{- end }}
+```

--- a/sync/patches/k8sservicehost_auto/_helpers.tpl.patch
+++ b/sync/patches/k8sservicehost_auto/_helpers.tpl.patch
@@ -1,31 +1,8 @@
-diff --git a/vendor/cilium/install/kubernetes/cilium/templates/_helpers.tpl b/helm/cilium/templates/_helpers.tpl
-index dc113ba..e550773 100644
---- a/vendor/cilium/install/kubernetes/cilium/templates/_helpers.tpl
+diff --git a/helm/cilium/templates/_helpers.tpl b/helm/cilium/templates/_helpers.tpl
+index f457443..ee81bf6 100644
+--- a/helm/cilium/templates/_helpers.tpl
 +++ b/helm/cilium/templates/_helpers.tpl
-@@ -28,12 +28,21 @@ your container engine doesn't support specifying both the tag and digest for
- instance).
- */}}
- {{- define "cilium.image" -}}
-+{{- if not (kindIs "slice" .) }}
-+{{- (fail (printf "required list, but got %q" (kindOf .))) }}
-+{{- end }}
-+{{- if (ne (len .) 2) }}
-+{{- (fail (printf "required list of 2 arguments, but got %d" (len .))) }}
-+{{- end }}
-+{{- $ := index . 0 }}
-+{{- with index . 1 }}
- {{- $digest := (.useDigest | default false) | ternary (printf "@%s" .digest) "" -}}
- {{- $tag := .tag | default "" | eq "" | ternary "" (printf ":%s" .tag) -}}
- {{- if .override -}}
- {{- printf "%s" .override -}}
- {{- else -}}
--{{- printf "%s%s%s" .repository $tag $digest -}}
-+{{- printf "%s/%s%s%s" $.Values.image.registry .repository $tag $digest -}}
-+{{- end -}}
- {{- end -}}
- {{- end -}}
- 
-@@ -131,12 +140,16 @@ To override the namespace and configMap when using `auto`:
+@@ -140,12 +140,16 @@ To override the namespace and configMap when using `auto`:
  {{- define "k8sServiceHost" }}
    {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
    {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}

--- a/sync/patches/k8sservicehost_auto/patch.sh
+++ b/sync/patches/k8sservicehost_auto/patch.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_dir=$(git rev-parse --show-toplevel) ; readonly repo_dir
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ; readonly script_dir
+
+cd "${repo_dir}"
+
+readonly script_dir_rel=".${script_dir#"${repo_dir}"}"
+
+set -x
+git apply "${script_dir_rel}/_helpers.tpl.patch"
+{ set +x; } 2>/dev/null

--- a/sync/sync.sh
+++ b/sync/sync.sh
@@ -18,6 +18,7 @@ helm dependency update helm/cilium/
 ./sync/patches/image_registries/patch.sh
 ./sync/patches/readme/patch.sh
 ./sync/patches/networkpolicies/patch.sh
+./sync/patches/k8sservicehost_auto/patch.sh
 ./sync/patches/values/patch.sh
 
 # Store diffs


### PR DESCRIPTION
<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

In some edge-case scenarios, the chart gets installed before kubeadm has had the chance to populate the cluster-info ConfigMap. In such cases the chart gets installed with "auto" as the k8s service host and cilium fails to start. This doesn't get remediated automatically. With this change, if "auto" is provided as values, the chart will fail to get installed if it can't find the cluster-info ConfigMap, and the installer will be forced to retry the chart installation.

---

## Checklist

- [x] I added a CHANGELOG entry
- [x] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
