### PR TITLE
add edge nodes anti affinity to cilium daemonset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add anti affinity for cilium daemonset for `edge` nodes.
+
 ## [1.4.1] - 2026-02-18
 
 ### Changed

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -252,6 +252,12 @@ affinity:
         labelSelector:
           matchLabels:
             k8s-app: cilium
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: node-role.kubernetes.io/edge
+          operator: DoesNotExist
 # -- Node selector for cilium-agent.
 nodeSelector:
   kubernetes.io/os: linux


### PR DESCRIPTION
This PR adds a node anti affinity to the `cilium` daemonset so that it doesn't schedule pods on "edge" nodes which are handled by another daemonset: `cilium-kubeedge`.

## Checklist

- [x] I added a CHANGELOG entry
- [ ] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
