### PR TITLE
fix: Try fixing flaky tests

### DIFF
--- a/tests/e2e/internal/readiness/readiness.go
+++ b/tests/e2e/internal/readiness/readiness.go
@@ -1,0 +1,92 @@
+// Package readiness provides stricter cluster-readiness wait conditions than
+// the stock clustertest helpers, tailored to guard the Cilium connectivity
+// test against transient worker-node churn.
+package readiness
+
+import (
+	"context"
+
+	"github.com/giantswarm/clustertest/v5/pkg/client"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+	"github.com/giantswarm/clustertest/v5/pkg/wait"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AllNodesAndDaemonSetsReady returns a WaitCondition that is satisfied only
+// when every Node reports Ready and every DaemonSet has all of its pods
+// scheduled AND available.
+//
+// The stock wait.AreAllDaemonSetsReady only compares CurrentNumberScheduled
+// against DesiredNumberScheduled. That is too weak to protect the Cilium
+// connectivity test: a DaemonSet pod on a node that is draining or being
+// replaced can still count as "scheduled" while its kubelet has already torn
+// the container down. cilium-cli then snapshots the agent pod list and, seconds
+// later, execs into a pod whose backing node is gone, producing:
+//
+//	Internal error occurred: error executing command in container:
+//	pods "ip-10-0-x-y.<region>.compute.internal" not found
+//
+// Gating on node readiness catches the churn directly, and gating on
+// NumberAvailable/NumberReady ensures the agent pods are actually usable before
+// the connectivity test picks one to exec into.
+func AllNodesAndDaemonSetsReady(ctx context.Context, kubeClient *client.Client) wait.WaitCondition {
+	return func() (bool, error) {
+		// Every node must be Ready. A node that is cordoned, draining or
+		// NotReady (e.g. mid-replacement) is exactly the condition that makes a
+		// Cilium agent pod vanish out from under the connectivity test.
+		nodeList := &corev1.NodeList{}
+		if err := kubeClient.List(ctx, nodeList); err != nil {
+			return false, err
+		}
+		if len(nodeList.Items) == 0 {
+			logger.Log("no nodes found yet")
+			return false, nil
+		}
+		for _, node := range nodeList.Items {
+			if node.DeletionTimestamp != nil {
+				logger.Log("node %s is terminating", node.Name)
+				return false, nil
+			}
+			ready := false
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == corev1.NodeReady {
+					ready = cond.Status == corev1.ConditionTrue
+					break
+				}
+			}
+			if !ready {
+				logger.Log("node %s is not Ready", node.Name)
+				return false, nil
+			}
+		}
+
+		// Every DaemonSet must have all pods scheduled, up to date, ready and
+		// available - not merely scheduled.
+		daemonSetList := &appsv1.DaemonSetList{}
+		if err := kubeClient.List(ctx, daemonSetList); err != nil {
+			return false, err
+		}
+		for _, ds := range daemonSetList.Items {
+			desired := ds.Status.DesiredNumberScheduled
+			status := ds.Status
+			if status.CurrentNumberScheduled != desired ||
+				status.UpdatedNumberScheduled != desired ||
+				status.NumberReady != desired ||
+				status.NumberAvailable != desired ||
+				status.NumberUnavailable != 0 {
+				logger.Log(
+					"daemonSet %s/%s not fully available: desired=%d scheduled=%d updated=%d ready=%d available=%d unavailable=%d",
+					ds.Namespace, ds.Name, desired,
+					status.CurrentNumberScheduled, status.UpdatedNumberScheduled,
+					status.NumberReady, status.NumberAvailable, status.NumberUnavailable,
+				)
+				return false, nil
+			}
+		}
+
+		logger.Log("All (%d) nodes Ready and all (%d) daemonSets fully available", len(nodeList.Items), len(daemonSetList.Items))
+		return true, nil
+	}
+}

--- a/tests/e2e/suites/basic/basic_suite_test.go
+++ b/tests/e2e/suites/basic/basic_suite_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/cilium-app/tests/e2e/internal/connectivity"
 	"github.com/giantswarm/cilium-app/tests/e2e/internal/metrics"
 	"github.com/giantswarm/cilium-app/tests/e2e/internal/polex"
+	"github.com/giantswarm/cilium-app/tests/e2e/internal/readiness"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	batchv1 "k8s.io/api/batch/v1"
@@ -87,12 +88,17 @@ func TestBasic(t *testing.T) {
 				wcName := state.GetCluster().Name
 				wcClient, _ := state.GetFramework().WC(wcName)
 
-				By("Waiting for all DaemonSets to be ready")
+				By("Waiting for all Nodes and DaemonSets to be ready and stable")
+				// A stricter gate than wait.AreAllDaemonSetsReady: it requires every
+				// Node to be Ready and every DaemonSet pod to be available (not just
+				// scheduled), held consistently over a ~60s window. This guards against
+				// transient CAPA worker-node churn that would otherwise delete a Cilium
+				// agent pod out from under the connectivity test.
 				Eventually(
 					wait.ConsistentWaitCondition(
-						wait.AreAllDaemonSetsReady(state.GetContext(), wcClient),
-						10,
-						time.Second,
+						readiness.AllNodesAndDaemonSetsReady(state.GetContext(), wcClient),
+						30,
+						2*time.Second,
 					)).
 					WithTimeout(15 * time.Minute).
 					WithPolling(wait.DefaultInterval).
@@ -104,8 +110,16 @@ func TestBasic(t *testing.T) {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				By("Running connectivity tests")
-				err = connectivity.Run(wcNamespace, wcName)
-				Expect(err).ShouldNot(HaveOccurred())
+				// cilium-cli snapshots the agent pod list once at init and execs into
+				// those pods seconds later. If a node vanishes in that window the run
+				// fails with `pods "<node>" not found`. That staleness is self-healing on
+				// a fresh attempt, so retry the whole run a few times before failing.
+				Eventually(func() error {
+					return connectivity.Run(wcNamespace, wcName)
+				}).
+					WithTimeout(15 * time.Minute).
+					WithPolling(30 * time.Second).
+					Should(Succeed())
 			})
 
 			It("should create the hubble-generate-certs CronJob and renew the Hubble certificates", func() {

--- a/tests/e2e/suites/capa-eni/capa_eni_suite_test.go
+++ b/tests/e2e/suites/capa-eni/capa_eni_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/giantswarm/cilium-app/tests/e2e/internal/connectivity"
 	"github.com/giantswarm/cilium-app/tests/e2e/internal/metrics"
 	"github.com/giantswarm/cilium-app/tests/e2e/internal/polex"
+	"github.com/giantswarm/cilium-app/tests/e2e/internal/readiness"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -84,12 +85,17 @@ func TestBasic(t *testing.T) {
 				wcName := state.GetCluster().Name
 				wcClient, _ := state.GetFramework().WC(wcName)
 
-				By("Waiting for all DaemonSets to be ready")
+				By("Waiting for all Nodes and DaemonSets to be ready and stable")
+				// A stricter gate than wait.AreAllDaemonSetsReady: it requires every
+				// Node to be Ready and every DaemonSet pod to be available (not just
+				// scheduled), held consistently over a ~60s window. This guards against
+				// transient CAPA worker-node churn that would otherwise delete a Cilium
+				// agent pod out from under the connectivity test.
 				Eventually(
 					wait.ConsistentWaitCondition(
-						wait.AreAllDaemonSetsReady(state.GetContext(), wcClient),
-						10,
-						time.Second,
+						readiness.AllNodesAndDaemonSetsReady(state.GetContext(), wcClient),
+						30,
+						2*time.Second,
 					)).
 					WithTimeout(15 * time.Minute).
 					WithPolling(wait.DefaultInterval).
@@ -101,8 +107,16 @@ func TestBasic(t *testing.T) {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				By("Running connectivity tests")
-				err = connectivity.Run(wcNamespace, wcName)
-				Expect(err).ShouldNot(HaveOccurred())
+				// cilium-cli snapshots the agent pod list once at init and execs into
+				// those pods seconds later. If a node vanishes in that window the run
+				// fails with `pods "<node>" not found`. That staleness is self-healing on
+				// a fresh attempt, so retry the whole run a few times before failing.
+				Eventually(func() error {
+					return connectivity.Run(wcNamespace, wcName)
+				}).
+					WithTimeout(15 * time.Minute).
+					WithPolling(30 * time.Second).
+					Should(Succeed())
 			})
 
 			It("ensure key metrics are available on mimir", func() {


### PR DESCRIPTION
This PR tries to fix the flaky tests we're seeing. 

```
  /app/tests/e2e/suites/basic/basic_suite_test.go:84                                                                                                                                                                                                           
    STEP: Waiting for all DaemonSets to be ready @ 07/22/26 16:08:45.111                                                                                                                                                                                       
    {"level":"info","ts":"2026-07-22T16:08:46Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    {"level":"info","ts":"2026-07-22T16:08:47Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    {"level":"info","ts":"2026-07-22T16:08:48Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    {"level":"info","ts":"2026-07-22T16:08:49Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    {"level":"info","ts":"2026-07-22T16:08:50Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    {"level":"info","ts":"2026-07-22T16:08:51Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    {"level":"info","ts":"2026-07-22T16:08:52Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    {"level":"info","ts":"2026-07-22T16:08:53Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    {"level":"info","ts":"2026-07-22T16:08:54Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    {"level":"info","ts":"2026-07-22T16:08:55Z","msg":"All (12) daemonSets have all daemon pods running"}                                                                                                                                                      
    STEP: Applying policy exceptions @ 07/22/26 16:08:56.112                                                                                                                                                                                                   
    STEP: Running connectivity tests @ 07/22/26 16:08:56.183                                                                                                                                                                                                   
  ⚠️   Unable to detect Cilium version, assuming v1.17.4 for connectivity tests: unable to parse Cilium version on pod "cilium-85vlb": unable to fetch cilium version on pod "cilium-85vlb": command failed (pod=kube-system/cilium-85vlb,                      
  container=cilium-agent): Internal error occurred: error executing command in container: pods "ip-10-0-176-2.eu-north-1.compute.internal" not found                                                                                                           
    [FAILED] in [It] - /app/tests/e2e/suites/basic/basic_suite_test.go:108 @ 07/22/26 16:09:02.743                                                                                                                                                             
  • [FAILED] [17.632 seconds]                                                                                                                                                                                                                                  
   App Tests [It] should pass cilium connectivity test                                                                                                                                                                                                         
  /app/tests/e2e/suites/basic/basic_suite_test.go:84                                                                                                                                                                                                           
                                                                                                                                                                                                                                                               
    [FAILED] Unexpected error:                                                                                                                                                                                                                                 
        <*errors.joinError | 0x231c313aa378>:                                                                                                                                                                                                                  
        failed to fetch cilium runtime config: command failed (pod=kube-system/cilium-85vlb, container=cilium-agent): Internal error occurred: error executing command in container: pods "ip-10-0-176-2.eu-north-1.compute.internal" not found                
        {                                                                                                                                                                                                                                                      
            errs: [                                                                                                                                                                                                                                            
                <*fmt.wrapError | 0x231c31b6c460>{                                                                                                                                                                                                             
                    msg: "failed to fetch cilium runtime config: command failed (pod=kube-system/cilium-85vlb, container=cilium-agent): Internal error occurred: error executing command in container: pods \"ip-10-0-176-2.eu-north-1.compute.internal\" not  
  found",                                                                                                                                                                                                                                                      
                    err: <*fmt.wrapError | 0x231c31b6c440>{                                                                                                                                                                                                    
                        msg: "command failed (pod=kube-system/cilium-85vlb, container=cilium-agent): Internal error occurred: error executing command in container: pods \"ip-10-0-176-2.eu-north-1.compute.internal\" not found",                             
                        err: <*errors.errorString | 0x231c30695670>{                                                                                                                                                                                           
                            s: "Internal error occurred: error executing command in container: pods \"ip-10-0-176-2.eu-north-1.compute.internal\" not found",                                                                                                  
                        },                                                                                                                                                                                                                                     
                    },                                                                                                                                                                                                                                         
                },                                                                                                                                                                                                                                             
            ],                                                                                                                                                                                                                                                 
        }                                                                                                                                                                                                                                                      
    occurred                                                                                                                                                                                                                                                   
    In [It] at: /app/tests/e2e/suites/basic/basic_suite_test.go:108 @ 07/22/26 16:09:02.743
```

/run app-test-suites
