### PR TITLE
chore: run E2E tests automatically on release PRs

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -1,0 +1,14 @@
+<!--
+Used verbatim as the body of release PRs created by giantswarm/github-workflows
+(see .github/workflows/zz_generated.create_release_pr.yaml).
+
+The `/run` line makes Tekton start the E2E tests as soon as the release PR is
+opened. app-test-suites runs every suite for each configured provider by
+default, so the full set runs before the release is tagged.
+
+See https://github.com/giantswarm/roadmap/issues/4334
+-->
+
+The full set of E2E test suites for this app runs automatically on this release PR.
+
+/run app-test-suites

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Run the E2E test suites automatically on release PRs by adding `.github/release-pr-body.md`.
+
 ### Removed
 
 - **Removed the `image.registry` value and the sync patch behind it** ([roadmap#3264](https://github.com/giantswarm/roadmap/issues/3264)). The registry is now part of each image's `repository` value, exactly as upstream ships it, so the chart no longer patches upstream's `cilium.image`/`cilium.operator.image` helpers into a `(list $ <image>)` signature and no longer rewrites all 35 call sites with `sed`. `helm/cilium/templates/_helpers.tpl` and `helm/cilium/templates/cilium-operator/_helpers.tpl` are now byte-identical to upstream, and 15 template patches disappear from `diffs/`.


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4334

Release PRs are created with an empty body, so the Tekton trigger that reads `/run ...` from the PR body never fires and the E2E tests run only if someone remembers to comment. This app ships in Giant Swarm releases, so an untested version can reach customers that way.

giantswarm/github-workflows#266 makes `create-release-pr` use `.github/release-pr-body.md` verbatim as the release PR body, so `/run app-test-suites` starts as soon as the release PR is opened. `app-test-suites` runs every suite for each provider in `tests/e2e/config.yaml` by default.

The cluster provider chart repos already ship the same file with `/run cluster-test-suites`.
